### PR TITLE
Updated thephpleague/oauth2-client branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
      "keywords":    ["Strava","API","OAuth","PHP","StravaPHP"],
     "require": {
         "educoder/pest": "1.0.0",
-        "league/oauth2-client": "dev-master"
+        "league/oauth2-client": "master"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
The `dev-master` branch doesn't exist anymore – this is a fix to point to the `master` oauth2-client branch.