### PR TITLE
curl post file

### DIFF
--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -232,7 +232,8 @@ class REST implements ServiceInterface {
             'commute' => $commute,
             'data_type' => $data_type,
             'external_id' => $external_id,
-            'file' => '@'.ltrim($file, '@'),
+            'file' => curl_file_create($file),
+            'file_hack' => '@'.ltrim($file, '@'),
         );
         $result = $this->adapter->post($path, $parameters, $this->getHeaders());
         return $this->format($result);


### PR DESCRIPTION
The new/proper way to send files via curl is to call 'curl_file_create' on the file filed. 
I left the 'file_hack' with old @-prefix so PEST lib know to send the whole request as multipart - that's quick & dirty workaround.