### PR TITLE
Fix parameter name

### DIFF
--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -400,7 +400,7 @@ class REST implements ServiceInterface
     {
         $path = '/segments/' . $id . '/leaderboard';
         $parameters = array(
-            'id' => $gender,
+            'gender' => $gender,
             'age_group' => $age_group,
             'weight_class' => $weight_class,
             'following' => $following,


### PR DESCRIPTION
`getSegmentLeaderboard()` was always returning Male leaderboards, even when called with a signature such as `getSegmentLeaderboard($segmentId, 'F')`