### PR TITLE
remove tailing slash from streams url

### DIFF
--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -482,7 +482,7 @@ class REST implements ServiceInterface
 
     public function getStreamsRoute($id)
     {
-        $path = '/routes/' . $id . '/streams/';
+        $path = '/routes/' . $id . '/streams';
 
         $result = $this->adapter->get($path, array(), $this->getHeaders());
         return $this->format($result);

--- a/tests/Strava/API/Service/RESTTest.php
+++ b/tests/Strava/API/Service/RESTTest.php
@@ -545,7 +545,7 @@ class RESTTest extends PHPUnit_Framework_TestCase
     {
         $pestMock = $this->getPestMock();
         $pestMock->expects($this->once())->method('get')
-            ->with($this->equalTo('/routes/1234/streams/'))
+            ->with($this->equalTo('/routes/1234/streams'))
             ->will($this->returnValue('{"response": 1}'));
 
         $service = new Strava\API\Service\REST('TOKEN', $pestMock);


### PR DESCRIPTION
Strava doesn't want the tailing slash. When the slash is there StravaAPI returns a 301 and the library breaks. Without the slash it works properly