### PR TITLE
Guzzle http client fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ use Strava\API\Exception;
 use Strava\API\Service\REST;
 
 try {
-    $adapter = new Pest('https://www.strava.com/api/v3');
+    $adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3']);
     $service = new REST($token, $adapter);  // Define your user token here.
     $client = new Client($service);
 
@@ -146,8 +146,8 @@ $oauth->getAccessToken($grant = 'authorization_code', $params = []);
 ### Strava\API\Client
 #### Usage
 ```php
-// REST adapter (We use `Pest` in this project)
-$adapter = new Pest('https://www.strava.com/api/v3');
+// REST adapter (We use `Guzzle` in this project)
+$adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3']);
 // Service to use (Service\Stub is also available for test purposes)
 $service = new Service\REST('RECEIVED-TOKEN', $adapter);
 
@@ -207,7 +207,7 @@ $client->getStreamsRoute($id);
 ### Used libraries
 - [Strava API](https://strava.github.io/api/)
 - [thephpleague/oauth2-client](https://github.com/thephpleague/oauth2-client/)
-- [educoder/pest](https://github.com/educoder/pest)
+- [guzzlehttp/guzzle](https://github.com/guzzle/guzzle)
 
 ### Development
 The StravaPHP library was created by Bas van Dorst, [software engineer](https://www.linkedin.com/in/basvandorst) and cyclist enthusiast.

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
   ],
   "require": {
     "php": ">=5.6",
-    "educoder/pest": "~1.0",
-    "league/oauth2-client": "~2.3"
+    "league/oauth2-client": "~2.3",
+    "guzzlehttp/guzzle": "~6.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "^5"
   },
   "license": "MIT",
   "authors": [

--- a/src/Strava/API/Factory.php
+++ b/src/Strava/API/Factory.php
@@ -1,8 +1,6 @@
 <?php
 namespace Strava\API;
 
-use Pest;
-
 /**
  * Factory class
  *
@@ -45,7 +43,7 @@ class Factory
      */
     public function getAPIClient($token)
     {
-        $adapter = new Pest(self::$endpoint);
+        $adapter = new \GuzzleHttp\Client(['base_uri' => self::$endpoint]);
         $service = new Service\REST($token, $adapter);
 
         $APIClient = new Client($service);

--- a/src/Strava/API/Factory.php
+++ b/src/Strava/API/Factory.php
@@ -13,7 +13,7 @@ class Factory
      * Strava V3 endpoint
      * @var string
      */
-    private static $endpoint = 'https://www.strava.com/api/v3';
+    private static $endpoint = 'https://www.strava.com/api/v3/';
 
     /**
      * Return a new instance of the OAuth Client

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -2,7 +2,8 @@
 
 namespace Strava\API\Service;
 
-use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Client;
+
 
 /**
  * Strava REST Service
@@ -14,7 +15,7 @@ class REST implements ServiceInterface
 {
     /**
      * REST adapter
-     * @var HttpClient
+     * @var Client
      */
     protected $adapter;
 
@@ -29,9 +30,9 @@ class REST implements ServiceInterface
      * of the REST adapter (Guzzle).
      *
      * @param string $token
-     * @param HttpClient $adapter
+     * @param Client $adapter
      */
-    public function __construct($token, HttpClient $adapter)
+    public function __construct($token, Client $adapter)
     {
         $this->token = $token;
         $this->adapter = $adapter;
@@ -45,16 +46,36 @@ class REST implements ServiceInterface
     /**
      * Get a request result.
      * Returns an array with a response body or and error code => reason.
-     * @param $response
+     * @param \GuzzleHttp\Psr7\Response $response
      * @return array|mixed
      */
-    public function getResult($response)
+    private function getResult($response)
     {
         $status = $response->getStatusCode();
         if ($status == 200) {
-            return json_decode($response->getBody());
+            return json_decode($response->getBody(), JSON_PRETTY_PRINT);
         } else {
             return [$status => $response->getReasonPhrase()];
+        }
+    }
+
+  /**
+   * Get an API request response and handle possible exceptions.
+   *
+   * @param string $method
+   * @param string $path
+   * @param array $parameters
+   *
+   * @return array|mixed|string
+   */
+    private function getResponse($method, $path, $parameters)
+    {
+        try {
+            $response = $this->adapter->request($method, $path, $parameters);
+            return $this->getResult($response);
+        }
+        catch (\Exception $e) {
+            return $e->getMessage();
         }
     }
 
@@ -65,16 +86,14 @@ class REST implements ServiceInterface
             $path = 'athletes/' . $id;
         }
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteStats($id)
     {
         $path = 'athletes/' . $id . '/stats';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteRoutes($id, $type = null, $after = null, $page = null, $per_page = null)
@@ -87,16 +106,14 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteClubs()
     {
         $path = 'athlete/clubs';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteActivities($before = null, $after = null, $page = null, $per_page = null)
@@ -109,8 +126,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteFriends($id = null, $page = null, $per_page = null)
@@ -124,8 +140,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteFollowers($id = null, $page = null, $per_page = null)
@@ -139,8 +154,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteBothFollowing($id, $page = null, $per_page = null)
@@ -151,8 +165,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteKom($id, $page = null, $per_page = null)
@@ -163,16 +176,14 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteZones()
     {
         $path = 'athlete/zones';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteStarredSegments($id = null, $page = null, $per_page = null)
@@ -187,8 +198,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function updateAthlete($city, $state, $country, $sex, $weight)
@@ -202,8 +212,7 @@ class REST implements ServiceInterface
             'weight' => $weight,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('PUT', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('PUT', $path, $parameters);
     }
 
     public function getActivityFollowing($before = null, $page = null, $per_page = null)
@@ -215,8 +224,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivity($id, $include_all_efforts = null)
@@ -226,8 +234,7 @@ class REST implements ServiceInterface
             'include_all_efforts' => $include_all_efforts,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityComments($id, $markdown = null, $page = null, $per_page = null)
@@ -239,8 +246,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityKudos($id, $page = null, $per_page = null)
@@ -251,8 +257,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityPhotos($id, $size = 2048, $photo_sources = 'true')
@@ -263,32 +268,28 @@ class REST implements ServiceInterface
             'photo_sources' => $photo_sources,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityZones($id)
     {
         $path = 'activities/' . $id . '/zones';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityLaps($id)
     {
         $path = 'activities/' . $id . '/laps';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityUploadStatus($id)
     {
         $path = 'uploads/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function createActivity($name, $type, $start_date_local, $elapsed_time, $description = null, $distance = null, $private = null, $trainer = null)
@@ -305,8 +306,7 @@ class REST implements ServiceInterface
             'trainer' => $trainer,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('POST', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('POST', $path, $parameters);
     }
 
     public function uploadActivity($file, $activity_type = null, $name = null, $description = null, $private = null, $trainer = null, $commute = null, $data_type = null, $external_id = null)
@@ -325,8 +325,7 @@ class REST implements ServiceInterface
             'file_hack' => '@' . ltrim($file, '@'),
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('POST', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('POST', $path, $parameters);
     }
 
     public function updateActivity($id, $name = null, $type = null, $private = false, $commute = false, $trainer = false, $gear_id = null, $description = null)
@@ -342,32 +341,28 @@ class REST implements ServiceInterface
             'description' => $description,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('PUT', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('PUT', $path, $parameters);
     }
 
     public function deleteActivity($id)
     {
         $path = 'activities/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('DELETE', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('DELETE', $path, $parameters);
     }
 
     public function getGear($id)
     {
         $path = 'gear/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClub($id)
     {
         $path = 'clubs/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClubMembers($id, $page = null, $per_page = null)
@@ -378,8 +373,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClubActivities($id, $page = null, $per_page = null)
@@ -390,56 +384,49 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClubAnnouncements($id)
     {
         $path = 'clubs/' . $id . '/announcements';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClubGroupEvents($id)
     {
         $path = 'clubs/' . $id . '/group_events';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function joinClub($id)
     {
         $path = 'clubs/' . $id . '/join';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('POST', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('POST', $path, $parameters);
     }
 
     public function leaveClub($id)
     {
         $path = 'clubs/' . $id . '/leave';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('POST', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('POST', $path, $parameters);
     }
 
     public function getRoute($id)
     {
         $path = 'routes/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getSegment($id)
     {
         $path = 'segments/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getSegmentLeaderboard($id, $gender = null, $age_group = null, $weight_class = null, $following = null, $club_id = null, $date_range = null, $context_entries = null, $page = null, $per_page = null)
@@ -457,8 +444,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getSegmentExplorer($bounds, $activity_type = 'riding', $min_cat = null, $max_cat = null)
@@ -471,8 +457,7 @@ class REST implements ServiceInterface
             'max_cat' => $max_cat,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getSegmentEffort($id, $athlete_id = null, $start_date_local = null, $end_date_local = null, $page = null, $per_page = null)
@@ -486,8 +471,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getStreamsActivity($id, $types, $resolution = null, $series_type = 'distance')
@@ -498,8 +482,7 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getStreamsEffort($id, $types, $resolution = null, $series_type = 'distance')
@@ -510,8 +493,7 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getStreamsSegment($id, $types, $resolution = null, $series_type = 'distance')
@@ -522,16 +504,14 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getStreamsRoute($id)
     {
         $path = 'routes/' . $id . '/streams';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->adapter->request('GET', $path, $parameters);
-        return $this->getResult($response);
+        return $this->getResponse('GET', $path, $parameters);
     }
 
 }

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace Strava\API\Service;
 
-use Pest;
+use \GuzzleHttp\Client;
 
 /**
  * Strava REST Service
@@ -13,7 +14,7 @@ class REST implements ServiceInterface
 {
     /**
      * REST adapter
-     * @var Pest
+     * @var Client
      */
     protected $adapter;
 
@@ -24,21 +25,37 @@ class REST implements ServiceInterface
     private $token = null;
 
     /**
-     * Inititate this REST servcie with the application token and a instance
-     * of the REST adapter (Pest)
+     * Initiate this REST service with the application token and a instance
+     * of the REST adapter (Guzzle).
      *
      * @param string $token
-     * @param Pest $adapter
+     * @param Client $adapter
      */
-    public function __construct($token, Pest $adapter)
+    public function __construct($token, Client $adapter)
     {
         $this->token = $token;
         $this->adapter = $adapter;
     }
 
-    private function getHeaders()
+    private function getToken()
     {
-        return array('Authorization: Bearer ' . $this->token);
+        return $this->token;
+    }
+
+    /**
+     * Get a request result.
+     * Returns an array with a response body or and error code => reason.
+     * @param $response
+     * @return array|mixed
+     */
+    public function getResult($response)
+    {
+        $status = $response->getStatusCode;
+        if ($status == 200) {
+            return json_decode($response->getBody());
+        } else {
+            return [$status => $response->getReasonPhrase()];
+        }
     }
 
     public function getAthlete($id = null)
@@ -47,48 +64,53 @@ class REST implements ServiceInterface
         if (isset($id) && $id !== null) {
             $path = '/athletes/' . $id;
         }
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteStats($id)
     {
         $path = '/athletes/' . $id . '/stats';
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteRoutes($id, $type = null, $after = null, $page = null, $per_page = null)
     {
         $path = '/athletes/' . $id . '/routes';
-        $parameters = array(
+        $parameters = [
             'type' => $type,
             'after' => $after,
             'page' => $page,
             'per_page' => $per_page,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteClubs()
     {
         $path = '/athlete/clubs';
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteActivities($before = null, $after = null, $page = null, $per_page = null)
     {
         $path = '/athlete/activities';
-        $parameters = array(
+        $parameters = [
             'before' => $before,
             'after' => $after,
             'page' => $page,
             'per_page' => $per_page,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteFriends($id = null, $page = null, $per_page = null)
@@ -97,13 +119,13 @@ class REST implements ServiceInterface
         if (isset($id) && $id !== null) {
             $path = '/athletes/' . $id . '/friends';
         }
-
-        $parameters = array(
+        $parameters = [
             'page' => $page,
             'per_page' => $per_page,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteFollowers($id = null, $page = null, $per_page = null)
@@ -112,44 +134,45 @@ class REST implements ServiceInterface
         if (isset($id) && $id !== null) {
             $path = '/athletes/' . $id . '/followers';
         }
-
-        $parameters = array(
+        $parameters = [
             'page' => $page,
             'per_page' => $per_page,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteBothFollowing($id, $page = null, $per_page = null)
     {
         $path = '/athletes/' . $id . '/both-following';
-
-        $parameters = array(
+        $parameters = [
             'page' => $page,
             'per_page' => $per_page,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteKom($id, $page = null, $per_page = null)
     {
         $path = '/athletes/' . $id . '/koms';
-
-        $parameters = array(
+        $parameters = [
             'page' => $page,
             'per_page' => $per_page,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteZones()
     {
         $path = '/athlete/zones';
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getAthleteStarredSegments($id = null, $page = null, $per_page = null)
@@ -159,110 +182,119 @@ class REST implements ServiceInterface
             $path = '/athletes/' . $id . '/segments/starred';
             // ...wrong in Strava documentation
         }
-
-        $parameters = array(
+        $parameters = [
             'page' => $page,
             'per_page' => $per_page,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function updateAthlete($city, $state, $country, $sex, $weight)
     {
         $path = '/athlete';
-        $parameters = array(
+        $parameters = [
             'city' => $city,
             'state' => $state,
             'country' => $country,
             'sex' => $sex,
             'weight' => $weight,
-        );
-        $result = $this->adapter->put($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('PUT', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getActivityFollowing($before = null, $page = null, $per_page = null)
     {
         $path = '/activities/following';
-        $parameters = array(
+        $parameters = [
             'before' => $before,
             'page' => $page,
-            'per_page' => $per_page
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'per_page' => $per_page,
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
-   
+
     public function getActivity($id, $include_all_efforts = null)
     {
         $path = '/activities/' . $id;
-        $parameters = array(
+        $parameters = [
             'include_all_efforts' => $include_all_efforts,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getActivityComments($id, $markdown = null, $page = null, $per_page = null)
     {
         $path = '/activities/' . $id . '/comments';
-        $parameters = array(
+        $parameters = [
             'markdown' => $markdown,
             'page' => $page,
-            'per_page' => $per_page
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'per_page' => $per_page,
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getActivityKudos($id, $page = null, $per_page = null)
     {
         $path = '/activities/' . $id . '/kudos';
-        $parameters = array(
+        $parameters = [
             'page' => $page,
-            'per_page' => $per_page
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'per_page' => $per_page,
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getActivityPhotos($id, $size = 2048, $photo_sources = 'true')
     {
         $path = '/activities/' . $id . '/photos';
-        $parameters = array(
+        $parameters = [
             'size' => $size,
             'photo_sources' => $photo_sources,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getActivityZones($id)
     {
         $path = '/activities/' . $id . '/zones';
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getActivityLaps($id)
     {
         $path = '/activities/' . $id . '/laps';
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getActivityUploadStatus($id)
     {
         $path = '/uploads/' . $id;
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function createActivity($name, $type, $start_date_local, $elapsed_time, $description = null, $distance = null, $private = null, $trainer = null)
     {
         $path = '/activities';
-        $parameters = array(
+        $parameters = [
             'name' => $name,
             'type' => $type,
             'start_date_local' => $start_date_local,
@@ -271,15 +303,16 @@ class REST implements ServiceInterface
             'distance' => $distance,
             'private' => $private,
             'trainer' => $trainer,
-        );
-        $result = $this->adapter->post($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('POST', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function uploadActivity($file, $activity_type = null, $name = null, $description = null, $private = null, $trainer = null, $commute = null, $data_type = null, $external_id = null)
     {
         $path = '/uploads';
-        $parameters = array(
+        $parameters = [
             'activity_type' => $activity_type,
             'name' => $name,
             'description' => $description,
@@ -290,15 +323,16 @@ class REST implements ServiceInterface
             'external_id' => $external_id,
             'file' => curl_file_create($file),
             'file_hack' => '@' . ltrim($file, '@'),
-        );
-        $result = $this->adapter->post($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('POST', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function updateActivity($id, $name = null, $type = null, $private = false, $commute = false, $trainer = false, $gear_id = null, $description = null)
     {
         $path = '/activities/' . $id;
-        $parameters = array(
+        $parameters = [
             'name' => $name,
             'type' => $type,
             'private' => $private,
@@ -306,100 +340,112 @@ class REST implements ServiceInterface
             'trainer' => $trainer,
             'gear_id' => $gear_id,
             'description' => $description,
-        );
-        $result = $this->adapter->put($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('PUT', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function deleteActivity($id)
     {
         $path = '/activities/' . $id;
-        $result = $this->adapter->delete($path, $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('DELETE', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getGear($id)
     {
         $path = '/gear/' . $id;
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getClub($id)
     {
         $path = '/clubs/' . $id;
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getClubMembers($id, $page = null, $per_page = null)
     {
         $path = '/clubs/' . $id . '/members';
-        $parameters = array(
+        $parameters = [
             'page' => $page,
             'per_page' => $per_page,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getClubActivities($id, $page = null, $per_page = null)
     {
         $path = '/clubs/' . $id . '/activities';
-        $parameters = array(
+        $parameters = [
             'page' => $page,
             'per_page' => $per_page,
-        );
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getClubAnnouncements($id)
     {
         $path = '/clubs/' . $id . '/announcements';
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getClubGroupEvents($id)
     {
         $path = '/clubs/' . $id . '/group_events';
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function joinClub($id)
     {
         $path = '/clubs/' . $id . '/join';
-        $result = $this->adapter->post($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('POST', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function leaveClub($id)
     {
         $path = '/clubs/' . $id . '/leave';
-        $result = $this->adapter->post($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('POST', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getRoute($id)
     {
         $path = '/routes/' . $id;
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getSegment($id)
     {
         $path = '/segments/' . $id;
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getSegmentLeaderboard($id, $gender = null, $age_group = null, $weight_class = null, $following = null, $club_id = null, $date_range = null, $context_entries = null, $page = null, $per_page = null)
     {
         $path = '/segments/' . $id . '/leaderboard';
-        $parameters = array(
+        $parameters = [
             'gender' => $gender,
             'age_group' => $age_group,
             'weight_class' => $weight_class,
@@ -408,92 +454,84 @@ class REST implements ServiceInterface
             'date_range' => $date_range,
             'context_entries' => $context_entries,
             'page' => $page,
-            'per_page' => $per_page
-        );
-
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'per_page' => $per_page,
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getSegmentExplorer($bounds, $activity_type = 'riding', $min_cat = null, $max_cat = null)
     {
         $path = '/segments/explore';
-        $parameters = array(
+        $parameters = [
             'bounds' => $bounds,
             'activity_type' => $activity_type,
             'min_cat' => $min_cat,
-            'max_cat' => $max_cat
-        );
-
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'max_cat' => $max_cat,
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getSegmentEffort($id, $athlete_id = null, $start_date_local = null, $end_date_local = null, $page = null, $per_page = null)
     {
         $path = '/segments/' . $id . '/all_efforts';
-        $parameters = array(
+        $parameters = [
             'athlete_id' => $athlete_id,
             'start_date_local' => $start_date_local,
             'end_date_local' => $end_date_local,
             'page' => $page,
-            'per_page' => $per_page
-        );
-
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'per_page' => $per_page,
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getStreamsActivity($id, $types, $resolution = null, $series_type = 'distance')
     {
         $path = '/activities/' . $id . '/streams/' . $types;
-        $parameters = array(
+        $parameters = [
             'resolution' => $resolution,
-            'series_type' => $series_type
-        );
-
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'series_type' => $series_type,
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getStreamsEffort($id, $types, $resolution = null, $series_type = 'distance')
     {
         $path = '/segment_efforts/' . $id . '/streams/' . $types;
-        $parameters = array(
+        $parameters = [
             'resolution' => $resolution,
-            'series_type' => $series_type
-        );
-
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'series_type' => $series_type,
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getStreamsSegment($id, $types, $resolution = null, $series_type = 'distance')
     {
         $path = '/segments/' . $id . '/streams/' . $types;
-        $parameters = array(
+        $parameters = [
             'resolution' => $resolution,
-            'series_type' => $series_type
-        );
-
-        $result = $this->adapter->get($path, $parameters, $this->getHeaders());
-        return $this->format($result);
+            'series_type' => $series_type,
+            'access_token' => $this->getToken(),
+        ];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
     public function getStreamsRoute($id)
     {
         $path = '/routes/' . $id . '/streams';
-
-        $result = $this->adapter->get($path, array(), $this->getHeaders());
-        return $this->format($result);
+        $parameters = ['access_token' => $this->getToken()];
+        $response = $this->adapter->request('GET', $path, $parameters);
+        return $this->getResult($response);
     }
 
-    /**
-     * Convert the JSON output to an array
-     * @param string $result
-     */
-    private function format($result)
-    {
-        return json_decode($result, true);
-    }
 }

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -50,7 +50,7 @@ class REST implements ServiceInterface
      */
     public function getResult($response)
     {
-        $status = $response->getStatusCode;
+        $status = $response->getStatusCode();
         if ($status == 200) {
             return json_decode($response->getBody());
         } else {

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -34,13 +34,16 @@ class REST implements ServiceInterface
      */
     public function __construct($token, Client $adapter)
     {
+        if (!is_object($token) && method_exists($token, 'getToken')) {
+            $token = $token->getToken();
+        }
         $this->token = $token;
         $this->adapter = $adapter;
     }
 
     private function getToken()
     {
-        return $this->token->getToken();
+        return $this->token;
     }
 
     /**

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -2,7 +2,7 @@
 
 namespace Strava\API\Service;
 
-use \GuzzleHttp\Client;
+use GuzzleHttp\Client as HttpClient;
 
 /**
  * Strava REST Service
@@ -14,7 +14,7 @@ class REST implements ServiceInterface
 {
     /**
      * REST adapter
-     * @var Client
+     * @var HttpClient
      */
     protected $adapter;
 
@@ -29,9 +29,9 @@ class REST implements ServiceInterface
      * of the REST adapter (Guzzle).
      *
      * @param string $token
-     * @param Client $adapter
+     * @param HttpClient $adapter
      */
-    public function __construct($token, Client $adapter)
+    public function __construct($token, HttpClient $adapter)
     {
         $this->token = $token;
         $this->adapter = $adapter;
@@ -64,7 +64,7 @@ class REST implements ServiceInterface
         if (isset($id) && $id !== null) {
             $path = 'athletes/' . $id;
         }
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -72,7 +72,7 @@ class REST implements ServiceInterface
     public function getAthleteStats($id)
     {
         $path = 'athletes/' . $id . '/stats';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -80,7 +80,7 @@ class REST implements ServiceInterface
     public function getAthleteRoutes($id, $type = null, $after = null, $page = null, $per_page = null)
     {
         $path = 'athletes/' . $id . '/routes';
-        $parameters = [
+        $parameters['query'] = [
             'type' => $type,
             'after' => $after,
             'page' => $page,
@@ -94,7 +94,7 @@ class REST implements ServiceInterface
     public function getAthleteClubs()
     {
         $path = 'athlete/clubs';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -102,7 +102,7 @@ class REST implements ServiceInterface
     public function getAthleteActivities($before = null, $after = null, $page = null, $per_page = null)
     {
         $path = 'athlete/activities';
-        $parameters = [
+        $parameters['query'] = [
             'before' => $before,
             'after' => $after,
             'page' => $page,
@@ -119,7 +119,7 @@ class REST implements ServiceInterface
         if (isset($id) && $id !== null) {
             $path = 'athletes/' . $id . '/friends';
         }
-        $parameters = [
+        $parameters['query'] = [
             'page' => $page,
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
@@ -134,7 +134,7 @@ class REST implements ServiceInterface
         if (isset($id) && $id !== null) {
             $path = 'athletes/' . $id . '/followers';
         }
-        $parameters = [
+        $parameters['query'] = [
             'page' => $page,
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
@@ -146,7 +146,7 @@ class REST implements ServiceInterface
     public function getAthleteBothFollowing($id, $page = null, $per_page = null)
     {
         $path = 'athletes/' . $id . '/both-following';
-        $parameters = [
+        $parameters['query'] = [
             'page' => $page,
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
@@ -158,7 +158,7 @@ class REST implements ServiceInterface
     public function getAthleteKom($id, $page = null, $per_page = null)
     {
         $path = 'athletes/' . $id . '/koms';
-        $parameters = [
+        $parameters['query'] = [
             'page' => $page,
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
@@ -170,7 +170,7 @@ class REST implements ServiceInterface
     public function getAthleteZones()
     {
         $path = 'athlete/zones';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -182,7 +182,7 @@ class REST implements ServiceInterface
             $path = 'athletes/' . $id . '/segments/starred';
             // ...wrong in Strava documentation
         }
-        $parameters = [
+        $parameters['query'] = [
             'page' => $page,
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
@@ -194,7 +194,7 @@ class REST implements ServiceInterface
     public function updateAthlete($city, $state, $country, $sex, $weight)
     {
         $path = 'athlete';
-        $parameters = [
+        $parameters['query'] = [
             'city' => $city,
             'state' => $state,
             'country' => $country,
@@ -209,7 +209,7 @@ class REST implements ServiceInterface
     public function getActivityFollowing($before = null, $page = null, $per_page = null)
     {
         $path = 'activities/following';
-        $parameters = [
+        $parameters['query'] = [
             'before' => $before,
             'page' => $page,
             'per_page' => $per_page,
@@ -222,7 +222,7 @@ class REST implements ServiceInterface
     public function getActivity($id, $include_all_efforts = null)
     {
         $path = 'activities/' . $id;
-        $parameters = [
+        $parameters['query'] = [
             'include_all_efforts' => $include_all_efforts,
             'access_token' => $this->getToken(),
         ];
@@ -233,7 +233,7 @@ class REST implements ServiceInterface
     public function getActivityComments($id, $markdown = null, $page = null, $per_page = null)
     {
         $path = 'activities/' . $id . '/comments';
-        $parameters = [
+        $parameters['query'] = [
             'markdown' => $markdown,
             'page' => $page,
             'per_page' => $per_page,
@@ -246,7 +246,7 @@ class REST implements ServiceInterface
     public function getActivityKudos($id, $page = null, $per_page = null)
     {
         $path = 'activities/' . $id . '/kudos';
-        $parameters = [
+        $parameters['query'] = [
             'page' => $page,
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
@@ -258,7 +258,7 @@ class REST implements ServiceInterface
     public function getActivityPhotos($id, $size = 2048, $photo_sources = 'true')
     {
         $path = 'activities/' . $id . '/photos';
-        $parameters = [
+        $parameters['query'] = [
             'size' => $size,
             'photo_sources' => $photo_sources,
             'access_token' => $this->getToken(),
@@ -270,7 +270,7 @@ class REST implements ServiceInterface
     public function getActivityZones($id)
     {
         $path = 'activities/' . $id . '/zones';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -278,7 +278,7 @@ class REST implements ServiceInterface
     public function getActivityLaps($id)
     {
         $path = 'activities/' . $id . '/laps';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -286,7 +286,7 @@ class REST implements ServiceInterface
     public function getActivityUploadStatus($id)
     {
         $path = 'uploads/' . $id;
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -294,7 +294,7 @@ class REST implements ServiceInterface
     public function createActivity($name, $type, $start_date_local, $elapsed_time, $description = null, $distance = null, $private = null, $trainer = null)
     {
         $path = 'activities';
-        $parameters = [
+        $parameters['query'] = [
             'name' => $name,
             'type' => $type,
             'start_date_local' => $start_date_local,
@@ -312,7 +312,7 @@ class REST implements ServiceInterface
     public function uploadActivity($file, $activity_type = null, $name = null, $description = null, $private = null, $trainer = null, $commute = null, $data_type = null, $external_id = null)
     {
         $path = 'uploads';
-        $parameters = [
+        $parameters['query'] = [
             'activity_type' => $activity_type,
             'name' => $name,
             'description' => $description,
@@ -332,7 +332,7 @@ class REST implements ServiceInterface
     public function updateActivity($id, $name = null, $type = null, $private = false, $commute = false, $trainer = false, $gear_id = null, $description = null)
     {
         $path = 'activities/' . $id;
-        $parameters = [
+        $parameters['query'] = [
             'name' => $name,
             'type' => $type,
             'private' => $private,
@@ -349,7 +349,7 @@ class REST implements ServiceInterface
     public function deleteActivity($id)
     {
         $path = 'activities/' . $id;
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('DELETE', $path, $parameters);
         return $this->getResult($response);
     }
@@ -357,7 +357,7 @@ class REST implements ServiceInterface
     public function getGear($id)
     {
         $path = 'gear/' . $id;
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -365,7 +365,7 @@ class REST implements ServiceInterface
     public function getClub($id)
     {
         $path = 'clubs/' . $id;
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -373,7 +373,7 @@ class REST implements ServiceInterface
     public function getClubMembers($id, $page = null, $per_page = null)
     {
         $path = 'clubs/' . $id . '/members';
-        $parameters = [
+        $parameters['query'] = [
             'page' => $page,
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
@@ -385,7 +385,7 @@ class REST implements ServiceInterface
     public function getClubActivities($id, $page = null, $per_page = null)
     {
         $path = 'clubs/' . $id . '/activities';
-        $parameters = [
+        $parameters['query'] = [
             'page' => $page,
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
@@ -397,7 +397,7 @@ class REST implements ServiceInterface
     public function getClubAnnouncements($id)
     {
         $path = 'clubs/' . $id . '/announcements';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -405,7 +405,7 @@ class REST implements ServiceInterface
     public function getClubGroupEvents($id)
     {
         $path = 'clubs/' . $id . '/group_events';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -413,7 +413,7 @@ class REST implements ServiceInterface
     public function joinClub($id)
     {
         $path = 'clubs/' . $id . '/join';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('POST', $path, $parameters);
         return $this->getResult($response);
     }
@@ -421,7 +421,7 @@ class REST implements ServiceInterface
     public function leaveClub($id)
     {
         $path = 'clubs/' . $id . '/leave';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('POST', $path, $parameters);
         return $this->getResult($response);
     }
@@ -429,7 +429,7 @@ class REST implements ServiceInterface
     public function getRoute($id)
     {
         $path = 'routes/' . $id;
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -437,7 +437,7 @@ class REST implements ServiceInterface
     public function getSegment($id)
     {
         $path = 'segments/' . $id;
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }
@@ -445,7 +445,7 @@ class REST implements ServiceInterface
     public function getSegmentLeaderboard($id, $gender = null, $age_group = null, $weight_class = null, $following = null, $club_id = null, $date_range = null, $context_entries = null, $page = null, $per_page = null)
     {
         $path = 'segments/' . $id . '/leaderboard';
-        $parameters = [
+        $parameters['query'] = [
             'gender' => $gender,
             'age_group' => $age_group,
             'weight_class' => $weight_class,
@@ -464,7 +464,7 @@ class REST implements ServiceInterface
     public function getSegmentExplorer($bounds, $activity_type = 'riding', $min_cat = null, $max_cat = null)
     {
         $path = 'segments/explore';
-        $parameters = [
+        $parameters['query'] = [
             'bounds' => $bounds,
             'activity_type' => $activity_type,
             'min_cat' => $min_cat,
@@ -478,7 +478,7 @@ class REST implements ServiceInterface
     public function getSegmentEffort($id, $athlete_id = null, $start_date_local = null, $end_date_local = null, $page = null, $per_page = null)
     {
         $path = 'segments/' . $id . '/all_efforts';
-        $parameters = [
+        $parameters['query'] = [
             'athlete_id' => $athlete_id,
             'start_date_local' => $start_date_local,
             'end_date_local' => $end_date_local,
@@ -493,7 +493,7 @@ class REST implements ServiceInterface
     public function getStreamsActivity($id, $types, $resolution = null, $series_type = 'distance')
     {
         $path = 'activities/' . $id . '/streams/' . $types;
-        $parameters = [
+        $parameters['query'] = [
             'resolution' => $resolution,
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
@@ -505,7 +505,7 @@ class REST implements ServiceInterface
     public function getStreamsEffort($id, $types, $resolution = null, $series_type = 'distance')
     {
         $path = 'segment_efforts/' . $id . '/streams/' . $types;
-        $parameters = [
+        $parameters['query'] = [
             'resolution' => $resolution,
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
@@ -517,7 +517,7 @@ class REST implements ServiceInterface
     public function getStreamsSegment($id, $types, $resolution = null, $series_type = 'distance')
     {
         $path = 'segments/' . $id . '/streams/' . $types;
-        $parameters = [
+        $parameters['query'] = [
             'resolution' => $resolution,
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
@@ -529,7 +529,7 @@ class REST implements ServiceInterface
     public function getStreamsRoute($id)
     {
         $path = 'routes/' . $id . '/streams';
-        $parameters = ['access_token' => $this->getToken()];
+        $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
     }

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -60,9 +60,9 @@ class REST implements ServiceInterface
 
     public function getAthlete($id = null)
     {
-        $path = '/athlete';
+        $path = 'athlete';
         if (isset($id) && $id !== null) {
-            $path = '/athletes/' . $id;
+            $path = 'athletes/' . $id;
         }
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
@@ -71,7 +71,7 @@ class REST implements ServiceInterface
 
     public function getAthleteStats($id)
     {
-        $path = '/athletes/' . $id . '/stats';
+        $path = 'athletes/' . $id . '/stats';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -79,7 +79,7 @@ class REST implements ServiceInterface
 
     public function getAthleteRoutes($id, $type = null, $after = null, $page = null, $per_page = null)
     {
-        $path = '/athletes/' . $id . '/routes';
+        $path = 'athletes/' . $id . '/routes';
         $parameters = [
             'type' => $type,
             'after' => $after,
@@ -93,7 +93,7 @@ class REST implements ServiceInterface
 
     public function getAthleteClubs()
     {
-        $path = '/athlete/clubs';
+        $path = 'athlete/clubs';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -101,7 +101,7 @@ class REST implements ServiceInterface
 
     public function getAthleteActivities($before = null, $after = null, $page = null, $per_page = null)
     {
-        $path = '/athlete/activities';
+        $path = 'athlete/activities';
         $parameters = [
             'before' => $before,
             'after' => $after,
@@ -115,9 +115,9 @@ class REST implements ServiceInterface
 
     public function getAthleteFriends($id = null, $page = null, $per_page = null)
     {
-        $path = '/athlete/friends';
+        $path = 'athlete/friends';
         if (isset($id) && $id !== null) {
-            $path = '/athletes/' . $id . '/friends';
+            $path = 'athletes/' . $id . '/friends';
         }
         $parameters = [
             'page' => $page,
@@ -130,9 +130,9 @@ class REST implements ServiceInterface
 
     public function getAthleteFollowers($id = null, $page = null, $per_page = null)
     {
-        $path = '/athlete/followers';
+        $path = 'athlete/followers';
         if (isset($id) && $id !== null) {
-            $path = '/athletes/' . $id . '/followers';
+            $path = 'athletes/' . $id . '/followers';
         }
         $parameters = [
             'page' => $page,
@@ -145,7 +145,7 @@ class REST implements ServiceInterface
 
     public function getAthleteBothFollowing($id, $page = null, $per_page = null)
     {
-        $path = '/athletes/' . $id . '/both-following';
+        $path = 'athletes/' . $id . '/both-following';
         $parameters = [
             'page' => $page,
             'per_page' => $per_page,
@@ -157,7 +157,7 @@ class REST implements ServiceInterface
 
     public function getAthleteKom($id, $page = null, $per_page = null)
     {
-        $path = '/athletes/' . $id . '/koms';
+        $path = 'athletes/' . $id . '/koms';
         $parameters = [
             'page' => $page,
             'per_page' => $per_page,
@@ -169,7 +169,7 @@ class REST implements ServiceInterface
 
     public function getAthleteZones()
     {
-        $path = '/athlete/zones';
+        $path = 'athlete/zones';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -177,9 +177,9 @@ class REST implements ServiceInterface
 
     public function getAthleteStarredSegments($id = null, $page = null, $per_page = null)
     {
-        $path = '/segments/starred';
+        $path = 'segments/starred';
         if (isset($id) && $id !== null) {
-            $path = '/athletes/' . $id . '/segments/starred';
+            $path = 'athletes/' . $id . '/segments/starred';
             // ...wrong in Strava documentation
         }
         $parameters = [
@@ -193,7 +193,7 @@ class REST implements ServiceInterface
 
     public function updateAthlete($city, $state, $country, $sex, $weight)
     {
-        $path = '/athlete';
+        $path = 'athlete';
         $parameters = [
             'city' => $city,
             'state' => $state,
@@ -208,7 +208,7 @@ class REST implements ServiceInterface
 
     public function getActivityFollowing($before = null, $page = null, $per_page = null)
     {
-        $path = '/activities/following';
+        $path = 'activities/following';
         $parameters = [
             'before' => $before,
             'page' => $page,
@@ -221,7 +221,7 @@ class REST implements ServiceInterface
 
     public function getActivity($id, $include_all_efforts = null)
     {
-        $path = '/activities/' . $id;
+        $path = 'activities/' . $id;
         $parameters = [
             'include_all_efforts' => $include_all_efforts,
             'access_token' => $this->getToken(),
@@ -232,7 +232,7 @@ class REST implements ServiceInterface
 
     public function getActivityComments($id, $markdown = null, $page = null, $per_page = null)
     {
-        $path = '/activities/' . $id . '/comments';
+        $path = 'activities/' . $id . '/comments';
         $parameters = [
             'markdown' => $markdown,
             'page' => $page,
@@ -245,7 +245,7 @@ class REST implements ServiceInterface
 
     public function getActivityKudos($id, $page = null, $per_page = null)
     {
-        $path = '/activities/' . $id . '/kudos';
+        $path = 'activities/' . $id . '/kudos';
         $parameters = [
             'page' => $page,
             'per_page' => $per_page,
@@ -257,7 +257,7 @@ class REST implements ServiceInterface
 
     public function getActivityPhotos($id, $size = 2048, $photo_sources = 'true')
     {
-        $path = '/activities/' . $id . '/photos';
+        $path = 'activities/' . $id . '/photos';
         $parameters = [
             'size' => $size,
             'photo_sources' => $photo_sources,
@@ -269,7 +269,7 @@ class REST implements ServiceInterface
 
     public function getActivityZones($id)
     {
-        $path = '/activities/' . $id . '/zones';
+        $path = 'activities/' . $id . '/zones';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -277,7 +277,7 @@ class REST implements ServiceInterface
 
     public function getActivityLaps($id)
     {
-        $path = '/activities/' . $id . '/laps';
+        $path = 'activities/' . $id . '/laps';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -285,7 +285,7 @@ class REST implements ServiceInterface
 
     public function getActivityUploadStatus($id)
     {
-        $path = '/uploads/' . $id;
+        $path = 'uploads/' . $id;
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -293,7 +293,7 @@ class REST implements ServiceInterface
 
     public function createActivity($name, $type, $start_date_local, $elapsed_time, $description = null, $distance = null, $private = null, $trainer = null)
     {
-        $path = '/activities';
+        $path = 'activities';
         $parameters = [
             'name' => $name,
             'type' => $type,
@@ -311,7 +311,7 @@ class REST implements ServiceInterface
 
     public function uploadActivity($file, $activity_type = null, $name = null, $description = null, $private = null, $trainer = null, $commute = null, $data_type = null, $external_id = null)
     {
-        $path = '/uploads';
+        $path = 'uploads';
         $parameters = [
             'activity_type' => $activity_type,
             'name' => $name,
@@ -331,7 +331,7 @@ class REST implements ServiceInterface
 
     public function updateActivity($id, $name = null, $type = null, $private = false, $commute = false, $trainer = false, $gear_id = null, $description = null)
     {
-        $path = '/activities/' . $id;
+        $path = 'activities/' . $id;
         $parameters = [
             'name' => $name,
             'type' => $type,
@@ -348,7 +348,7 @@ class REST implements ServiceInterface
 
     public function deleteActivity($id)
     {
-        $path = '/activities/' . $id;
+        $path = 'activities/' . $id;
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('DELETE', $path, $parameters);
         return $this->getResult($response);
@@ -356,7 +356,7 @@ class REST implements ServiceInterface
 
     public function getGear($id)
     {
-        $path = '/gear/' . $id;
+        $path = 'gear/' . $id;
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -364,7 +364,7 @@ class REST implements ServiceInterface
 
     public function getClub($id)
     {
-        $path = '/clubs/' . $id;
+        $path = 'clubs/' . $id;
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -372,7 +372,7 @@ class REST implements ServiceInterface
 
     public function getClubMembers($id, $page = null, $per_page = null)
     {
-        $path = '/clubs/' . $id . '/members';
+        $path = 'clubs/' . $id . '/members';
         $parameters = [
             'page' => $page,
             'per_page' => $per_page,
@@ -384,7 +384,7 @@ class REST implements ServiceInterface
 
     public function getClubActivities($id, $page = null, $per_page = null)
     {
-        $path = '/clubs/' . $id . '/activities';
+        $path = 'clubs/' . $id . '/activities';
         $parameters = [
             'page' => $page,
             'per_page' => $per_page,
@@ -396,7 +396,7 @@ class REST implements ServiceInterface
 
     public function getClubAnnouncements($id)
     {
-        $path = '/clubs/' . $id . '/announcements';
+        $path = 'clubs/' . $id . '/announcements';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -404,7 +404,7 @@ class REST implements ServiceInterface
 
     public function getClubGroupEvents($id)
     {
-        $path = '/clubs/' . $id . '/group_events';
+        $path = 'clubs/' . $id . '/group_events';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -412,7 +412,7 @@ class REST implements ServiceInterface
 
     public function joinClub($id)
     {
-        $path = '/clubs/' . $id . '/join';
+        $path = 'clubs/' . $id . '/join';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('POST', $path, $parameters);
         return $this->getResult($response);
@@ -420,7 +420,7 @@ class REST implements ServiceInterface
 
     public function leaveClub($id)
     {
-        $path = '/clubs/' . $id . '/leave';
+        $path = 'clubs/' . $id . '/leave';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('POST', $path, $parameters);
         return $this->getResult($response);
@@ -428,7 +428,7 @@ class REST implements ServiceInterface
 
     public function getRoute($id)
     {
-        $path = '/routes/' . $id;
+        $path = 'routes/' . $id;
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -436,7 +436,7 @@ class REST implements ServiceInterface
 
     public function getSegment($id)
     {
-        $path = '/segments/' . $id;
+        $path = 'segments/' . $id;
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);
@@ -444,7 +444,7 @@ class REST implements ServiceInterface
 
     public function getSegmentLeaderboard($id, $gender = null, $age_group = null, $weight_class = null, $following = null, $club_id = null, $date_range = null, $context_entries = null, $page = null, $per_page = null)
     {
-        $path = '/segments/' . $id . '/leaderboard';
+        $path = 'segments/' . $id . '/leaderboard';
         $parameters = [
             'gender' => $gender,
             'age_group' => $age_group,
@@ -463,7 +463,7 @@ class REST implements ServiceInterface
 
     public function getSegmentExplorer($bounds, $activity_type = 'riding', $min_cat = null, $max_cat = null)
     {
-        $path = '/segments/explore';
+        $path = 'segments/explore';
         $parameters = [
             'bounds' => $bounds,
             'activity_type' => $activity_type,
@@ -477,7 +477,7 @@ class REST implements ServiceInterface
 
     public function getSegmentEffort($id, $athlete_id = null, $start_date_local = null, $end_date_local = null, $page = null, $per_page = null)
     {
-        $path = '/segments/' . $id . '/all_efforts';
+        $path = 'segments/' . $id . '/all_efforts';
         $parameters = [
             'athlete_id' => $athlete_id,
             'start_date_local' => $start_date_local,
@@ -492,7 +492,7 @@ class REST implements ServiceInterface
 
     public function getStreamsActivity($id, $types, $resolution = null, $series_type = 'distance')
     {
-        $path = '/activities/' . $id . '/streams/' . $types;
+        $path = 'activities/' . $id . '/streams/' . $types;
         $parameters = [
             'resolution' => $resolution,
             'series_type' => $series_type,
@@ -504,7 +504,7 @@ class REST implements ServiceInterface
 
     public function getStreamsEffort($id, $types, $resolution = null, $series_type = 'distance')
     {
-        $path = '/segment_efforts/' . $id . '/streams/' . $types;
+        $path = 'segment_efforts/' . $id . '/streams/' . $types;
         $parameters = [
             'resolution' => $resolution,
             'series_type' => $series_type,
@@ -516,7 +516,7 @@ class REST implements ServiceInterface
 
     public function getStreamsSegment($id, $types, $resolution = null, $series_type = 'distance')
     {
-        $path = '/segments/' . $id . '/streams/' . $types;
+        $path = 'segments/' . $id . '/streams/' . $types;
         $parameters = [
             'resolution' => $resolution,
             'series_type' => $series_type,
@@ -528,7 +528,7 @@ class REST implements ServiceInterface
 
     public function getStreamsRoute($id)
     {
-        $path = '/routes/' . $id . '/streams';
+        $path = 'routes/' . $id . '/streams';
         $parameters = ['access_token' => $this->getToken()];
         $response = $this->adapter->request('GET', $path, $parameters);
         return $this->getResult($response);

--- a/tests/Strava/API/Service/RESTTest.php
+++ b/tests/Strava/API/Service/RESTTest.php
@@ -9,190 +9,190 @@
  */
 class RESTTest extends PHPUnit_Framework_TestCase
 {
-    private function getPestMock()
+    private function getRestMock()
     {
-        $pestMock = $this->getMockBuilder('Pest')
+        $restMock = $this->getMockBuilder('\GuzzleHttp\Client')
             ->disableOriginalConstructor()
             ->getMock();
-        return $pestMock;
+        return $restMock;
     }
 
     public function testGetAthlete()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athlete'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthlete();
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteWithId()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athletes/1234'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthlete(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetStats()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athletes/1234/stats'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteStats(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetRoutes()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athletes/1234/routes'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteRoutes(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteClubs()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athlete/clubs'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteClubs();
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteActivities()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athlete/activities'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteActivities();
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteFriends()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athlete/friends'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteFriends();
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteFriendsWithId()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athletes/1234/friends'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteFriends(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteFollowers()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athlete/followers'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteFollowers();
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteFollowersWithId()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athletes/1234/followers'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteFollowers(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteBothFollowing()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athletes/1234/both-following'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteBothFollowing(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteKOM()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athletes/1234/koms'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteKom(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteZones()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athlete/zones'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteZones();
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteStarredSegments()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/segments/starred'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteStarredSegments();
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetAthleteStarredSegmentsWithId()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/athletes/1234/segments/starred'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getAthleteStarredSegments(1234);
         $this->assertArrayHasKey('response', $output);
     }
@@ -207,348 +207,348 @@ class RESTTest extends PHPUnit_Framework_TestCase
             'weight' => 83.00,
         );
 
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('put')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('put')
             ->with($this->equalTo('/athlete'), $this->equalTo($parameters))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->updateAthlete('Xyz', 'ABC', 'The Netherlands', 'M', 83.00);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetActivity()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/activities/1234'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getActivity(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetActivityComments()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/activities/1234/comments'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getActivityComments(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetActivityKudos()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/activities/1234/kudos'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getActivityKudos(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetActivityPhotos()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/activities/1234/photos'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getActivityPhotos(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetActivityZones()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/activities/1234/zones'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getActivityZones(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetActivityLaps()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/activities/1234/laps'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getActivityLaps(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetActivityUploadStatus()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/uploads/1234'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getActivityUploadStatus(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testCreateActivity()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('post')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('post')
             ->with($this->equalTo('/activities'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->createActivity('test', 'test', '20130101', 100);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testUploadActivity()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('post')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('post')
             ->with($this->equalTo('/uploads'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->uploadActivity('file');
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testUpdateActivity()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('put')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('put')
             ->with($this->equalTo('/activities/1234'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->updateActivity(1234, 'test');
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testDeleteActivity()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('delete')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('delete')
             ->with($this->equalTo('/activities/1234'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->deleteActivity(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetGear()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/gear/1234'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getGear(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetClub()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/clubs/1234'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getClub(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetClubMembers()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/clubs/1234/members'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getClubMembers(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetClubActivities()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/clubs/1234/activities'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getClubActivities(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetClubAnnouncements()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/clubs/1234/announcements'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getClubAnnouncements(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetClubGroupEvents()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/clubs/1234/group_events'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getClubGroupEvents(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testJoinClub()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('post')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('post')
             ->with($this->equalTo('/clubs/1234/join'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->joinClub(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testLeaveClub()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('post')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('post')
             ->with($this->equalTo('/clubs/1234/leave'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->leaveClub(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetRoute()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/routes/1234'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getRoute(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetSegment()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/segments/1234'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getSegment(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetSegmentLeaderboard()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/segments/1234/leaderboard'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getSegmentLeaderboard(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetSegmentExplorer()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/segments/explore'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getSegmentExplorer('37.821362,-122.505373,37.842038,-122.465977');
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetSegmentEffort()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/segments/1234/all_efforts'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getSegmentEffort(1234);
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetStreamsActivity()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/activities/1234/streams/latlng'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getStreamsActivity(1234, 'latlng');
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetStreamsEffort()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/segment_efforts/1234/streams/latlng'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getStreamsEffort(1234, 'latlng');
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetStreamsSegment()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/segments/1234/streams/latlng'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getStreamsSegment(1234, 'latlng');
         $this->assertArrayHasKey('response', $output);
     }
 
     public function testGetStreamsRoute()
     {
-        $pestMock = $this->getPestMock();
-        $pestMock->expects($this->once())->method('get')
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
             ->with($this->equalTo('/routes/1234/streams'))
             ->will($this->returnValue('{"response": 1}'));
 
-        $service = new Strava\API\Service\REST('TOKEN', $pestMock);
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
         $output = $service->getStreamsRoute(1234);
         $this->assertArrayHasKey('response', $output);
     }


### PR DESCRIPTION
Strava endpoint needs a trailing slash for Guzzle http client. Otherwise the client will revert to https://www.strava.com/api/ and all api requests will return a 404.