### PR TITLE
Fix for access tokens and 401 responses

### DIFF
--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -40,7 +40,7 @@ class REST implements ServiceInterface
 
     private function getToken()
     {
-        return $this->token;
+        return $this->token->getToken();
     }
 
     /**


### PR DESCRIPTION
Strava rejected my requests with 401 as I did not send a valid access token. It turned out we handed over the whole token object, but Strava did only want to see the access token as a string. This is just a quick fix, maybe it would be nicer to introduce a new method like

    public function getAccessToken(): string
    {
        return $this->token->getToken();
    }