### PR TITLE
Ability to export routes as GPX and TCX

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ $client->getClub($id);
 $client->getClubMembers($id, $page = null, $per_page = null);
 $client->getClubActivities($id, $page = null, $per_page = null);
 $client->getRoute($id);
+$client->getRouteAsGPX($id);
+$client->getRouteAsTCX($id);
 $client->getSegment($id);
 $client->getSegmentLeaderboard($id, $gender = null, $age_group = null, $weight_class = null, $following = null, $club_id = null, $date_range = null, $page = null, $per_page = null);
 $client->getSegmentExplorer($bounds, $activity_type = 'riding', $min_cat = null, $max_cat = null);

--- a/src/Strava/API/Client.php
+++ b/src/Strava/API/Client.php
@@ -652,6 +652,40 @@ class Client
     }
 
     /**
+     * Get route as GPX.
+     *
+     * @link    https://developers.strava.com/docs/reference/#api-Routes-getRouteAsGPX
+     * @param   int $id
+     * @return  string
+     * @throws  Exception
+     */
+    public function getRouteAsGPX($id)
+    {
+        try {
+            return $this->service->getRouteAsGPX($id);
+        } catch (ServerException $e) {
+            throw new ClientException('[SERVICE] ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Get route as TCX.
+     *
+     * @link    https://developers.strava.com/docs/reference/#api-Routes-getRouteAsTCX
+     * @param   int $id
+     * @return  string
+     * @throws  Exception
+     */
+    public function getRouteAsTCX($id)
+    {
+        try {
+            return $this->service->getRouteAsTCX($id);
+        } catch (ServerException $e) {
+            throw new ClientException('[SERVICE] ' . $e->getMessage());
+        }
+    }
+
+    /**
      * Retrieve a segment
      *
      * @link    https://strava.github.io/api/v3/segments/#retrieve

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -47,16 +47,23 @@ class REST implements ServiceInterface
      * Get a request result.
      * Returns an array with a response body or and error code => reason.
      * @param \GuzzleHttp\Psr7\Response $response
-     * @return array|mixed
+     * @return array|mixed|string
      */
     private function getResult($response)
     {
         $status = $response->getStatusCode();
-        if ($status == 200) {
-            return json_decode($response->getBody(), JSON_PRETTY_PRINT);
-        } else {
+
+        if ($status !== 200) {
             return [$status => $response->getReasonPhrase()];
         }
+
+        $contentType = $response->getHeader('Content-Type');
+
+        if (false !== strpos(current($contentType), 'application/json')) {
+            return json_decode($response->getBody(), JSON_PRETTY_PRINT);
+        }
+
+        return (string) $response->getBody();
     }
 
   /**
@@ -418,6 +425,20 @@ class REST implements ServiceInterface
     public function getRoute($id)
     {
         $path = 'routes/' . $id;
+        $parameters['query'] = ['access_token' => $this->getToken()];
+        return $this->getResponse('GET', $path, $parameters);
+    }
+
+    public function getRouteAsGPX($id)
+    {
+        $path = 'routes/' . $id . '/export_gpx';
+        $parameters['query'] = ['access_token' => $this->getToken()];
+        return $this->getResponse('GET', $path, $parameters);
+    }
+
+    public function getRouteAsTCX($id)
+    {
+        $path = 'routes/' . $id . '/export_tcx';
         $parameters['query'] = ['access_token' => $this->getToken()];
         return $this->getResponse('GET', $path, $parameters);
     }

--- a/src/Strava/API/Service/ServiceInterface.php
+++ b/src/Strava/API/Service/ServiceInterface.php
@@ -2,7 +2,7 @@
 namespace Strava\API\Service;
 
 /**
- * Service interace.
+ * Service interface.
  * Just to make sure we can trust the method signatures of all the
  * service classes.
  *
@@ -227,6 +227,16 @@ interface ServiceInterface
      * @param integer $id
      */
     public function getRoute($id);
+
+    /**
+     * @param $id
+     */
+    public function getRouteAsGPX($id);
+
+    /**
+     * @param $id
+     */
+    public function getRouteAsTCX($id);
 
     /**
      * @param integer $id

--- a/src/Strava/API/Service/Stub.php
+++ b/src/Strava/API/Service/Stub.php
@@ -206,7 +206,19 @@ class Stub implements ServiceInterface
         $json = '{"response": 1}';
         return $this->format($json);
     }
-    
+
+    public function getRouteAsGPX($id)
+    {
+        $gpx = '<?xml version="1.0" encoding="UTF-8"?><gpx creator="StravaGPX"/>';
+        return $gpx;
+    }
+
+    public function getRouteAsTCX($id)
+    {
+        $tcx = '<?xml version="1.0" encoding="UTF-8"?><TrainingCenterDatabase/>';
+        return $tcx;
+    }
+
     public function getSegment($id)
     {
         $json = '{"response": 1}';

--- a/tests/Strava/API/Service/RESTTest.php
+++ b/tests/Strava/API/Service/RESTTest.php
@@ -457,6 +457,30 @@ class RESTTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('response', $output);
     }
 
+    public function testGetRouteAsGPX()
+    {
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
+            ->with($this->equalTo('/routes/1234/export_gpx'))
+            ->will($this->returnValue('<?xml version="1.0" encoding="UTF-8"?><gpx creator="StravaGPX"/>'));
+
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
+        $output = $service->getRouteAsGPX(1234);
+        $this->assertInternalType('string', $output);
+    }
+
+    public function testGetRouteAsTCX()
+    {
+        $restMock = $this->getRestMock();
+        $restMock->expects($this->once())->method('get')
+            ->with($this->equalTo('/routes/1234/export_tcx'))
+            ->will($this->returnValue('<?xml version="1.0" encoding="UTF-8"?><TrainingCenterDatabase/>'));
+
+        $service = new Strava\API\Service\REST('TOKEN', $restMock);
+        $output = $service->getRouteAsTCX(1234);
+        $this->assertInternalType('string', $output);
+    }
+
     public function testGetSegment()
     {
         $restMock = $this->getRestMock();

--- a/tests/Strava/API/Service/StubTest.php
+++ b/tests/Strava/API/Service/StubTest.php
@@ -233,6 +233,19 @@ class StubTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_array($output));
     }
 
+    public function testGetRouteAsGPX()
+    {
+        $service = new Strava\API\Service\Stub();
+        $output = $service->getRouteAsGPX(1234);
+        $this->assertTrue(is_string($output));
+    }
+
+    public function testGetRouteAsTCX()
+    {
+        $service = new Strava\API\Service\Stub();
+        $output = $service->getRouteAsTCX(1234);
+        $this->assertTrue(is_string($output));
+    }
 
     public function testGetSegment()
     {


### PR DESCRIPTION
Added `getRouteAsGPX($id)` and `getRouteAsTCX($id)` to the `\Strava\API\Client` class.