### PR TITLE
fix(readme): add trailing slash to base uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ use Strava\API\Exception;
 use Strava\API\Service\REST;
 
 try {
-    $adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3']);
+    $adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3/']);
     $service = new REST($token, $adapter);  // Define your user token here.
     $client = new Client($service);
 
@@ -147,7 +147,7 @@ $oauth->getAccessToken($grant = 'authorization_code', $params = []);
 #### Usage
 ```php
 // REST adapter (We use `Guzzle` in this project)
-$adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3']);
+$adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3/']);
 // Service to use (Service\Stub is also available for test purposes)
 $service = new Service\REST('RECEIVED-TOKEN', $adapter);
 


### PR DESCRIPTION
As https://stackoverflow.com/a/52915343 point out, the basuc uri is not correct in the readme