### PR TITLE
update v3 Api client URI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ use Strava\API\Exception;
 use Strava\API\Service\REST;
 
 try {
-    $adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3']);
+    $adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3/']);
     $service = new REST($token, $adapter);  // Define your user token here.
     $client = new Client($service);
 
@@ -147,7 +147,7 @@ $oauth->getAccessToken($grant = 'authorization_code', $params = []);
 #### Usage
 ```php
 // REST adapter (We use `Guzzle` in this project)
-$adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3']);
+$adapter = new \GuzzleHttp\Client(['base_uri' => 'https://www.strava.com/api/v3/']);
 // Service to use (Service\Stub is also available for test purposes)
 $service = new Service\REST('RECEIVED-TOKEN', $adapter);
 


### PR DESCRIPTION
Without the trailing slash the API will request https://www.strava.com/api/athlete instead of https://www.strava.com/api/v3/athlete causing the call to fail with a 404.