### PR TITLE
Changed private members in REST.php to protected, to make it possible to extend this class

### DIFF
--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -23,7 +23,7 @@ class REST implements ServiceInterface
      * Application token
      * @var string
      */
-    private $token;
+    protected $token;
 
     /**
      * Initiate this REST service with the application token and a instance
@@ -41,7 +41,7 @@ class REST implements ServiceInterface
         $this->adapter = $adapter;
     }
 
-    private function getToken()
+    protected function getToken()
     {
         return $this->token;
     }
@@ -52,7 +52,7 @@ class REST implements ServiceInterface
      * @param Response $response
      * @return array|mixed
      */
-    private function getResult($response)
+    protected function getResult($response)
     {
         $status = $response->getStatusCode();
 
@@ -74,7 +74,7 @@ class REST implements ServiceInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    private function getResponse($method, $path, $parameters)
+    protected function getResponse($method, $path, $parameters)
     {
         try {
             $response = $this->adapter->request($method, $path, $parameters);


### PR DESCRIPTION
It's impossible to override the class when helper methods such as getResponse() are marked as "private" because they are called by so many public methods.

This changes the 4 private members that exist in the class to protected so that developers can extend the class.

Thanks!