### PR TITLE
Add response verbosity, default to basic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - 7.1
+  - 7.3
 install:
   - composer --no-interaction install
 script: phpunit --configuration phpunit.xml --coverage-clover=coverage.clover

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -34,11 +34,12 @@ class REST implements ServiceInterface
     protected $responseVerbosity;
 
     /**
-     * Initiate this REST service with the application token and a instance
-     * of the REST adapter (Guzzle).
+     * Initiate this REST service with the application token, a instance
+     * of the REST adapter (Guzzle) and a level of verbosity for the response.
      *
      * @param string $token
      * @param Client $adapter
+     * @param integer $responseVerbosity
      */
     public function __construct($token, Client $adapter, $responseVerbosity = 0)
     {

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -70,7 +70,7 @@ class REST implements ServiceInterface
 
         $expandedResponse['headers'] = $response->getHeaders();
         $expandedResponse['body'] = json_decode($response->getBody(), JSON_PRETTY_PRINT);
-        $expandedResponse['success'] = $status == 200 || $status == 201;
+        $expandedResponse['success'] = $status === 200 || $status === 201;
         $expandedResponse['status'] = $status;
 
         return $expandedResponse;
@@ -108,7 +108,7 @@ class REST implements ServiceInterface
 
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response["body"];
 
         return $response;

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -29,7 +29,7 @@ class REST implements ServiceInterface
      * Specifies the verbosity of the HTTP response
      * 0 = basic, just body
      * 1 = enhanced, [body, headers, status]
-     * @var int|mixed
+     * @var int
      */
     protected $responseVerbosity;
 
@@ -39,7 +39,7 @@ class REST implements ServiceInterface
      *
      * @param string $token
      * @param Client $adapter
-     * @param integer $responseVerbosity
+     * @param int $responseVerbosity
      */
     public function __construct($token, Client $adapter, $responseVerbosity = 0)
     {

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -120,7 +120,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -137,7 +137,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -148,7 +148,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -165,7 +165,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -183,7 +183,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -201,7 +201,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -216,7 +216,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -231,7 +231,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -242,7 +242,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -261,7 +261,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -279,7 +279,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('PUT', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -293,7 +293,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -309,7 +309,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -324,7 +324,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -339,7 +339,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -350,7 +350,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -361,7 +361,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -372,7 +372,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -393,7 +393,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('POST', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -416,7 +416,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('POST', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -436,7 +436,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('PUT', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -447,7 +447,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('DELETE', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -458,7 +458,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -469,7 +469,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -484,7 +484,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -499,7 +499,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -510,7 +510,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -521,7 +521,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -532,7 +532,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('POST', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -543,7 +543,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('POST', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -554,7 +554,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -565,7 +565,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -576,7 +576,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -587,7 +587,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -609,7 +609,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -626,7 +626,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -644,7 +644,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -659,7 +659,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -674,7 +674,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -689,7 +689,7 @@ class REST implements ServiceInterface
         ];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }
@@ -700,7 +700,7 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
+        if ($this->responseVerbosity === 0)
             return $response['body'];
         return $response;
     }

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -26,19 +26,28 @@ class REST implements ServiceInterface
     protected $token;
 
     /**
+     * Specifies the verbosity of the HTTP response
+     * 0 = basic, just body
+     * 1 = enhanced, [body, headers, status]
+     * @var int|mixed
+     */
+    protected $responseVerbosity;
+
+    /**
      * Initiate this REST service with the application token and a instance
      * of the REST adapter (Guzzle).
      *
      * @param string $token
      * @param Client $adapter
      */
-    public function __construct($token, Client $adapter)
+    public function __construct($token, Client $adapter, $responseVerbosity = 0)
     {
         if (is_object($token) && method_exists($token, 'getToken')) {
             $token = $token->getToken();
         }
         $this->token = $token;
         $this->adapter = $adapter;
+        $this->responseVerbosity = $responseVerbosity;
     }
 
     protected function getToken()
@@ -56,11 +65,14 @@ class REST implements ServiceInterface
     {
         $status = $response->getStatusCode();
 
-        if ($status == 200 || $status == 201) {
-            return json_decode($response->getBody(), JSON_PRETTY_PRINT);
-        } else {
-            return [$status => $response->getReasonPhrase()];
-        }
+        $expandedResponse = [];
+
+        $expandedResponse['headers'] = $response->getHeaders();
+        $expandedResponse['body'] = json_decode($response->getBody(), JSON_PRETTY_PRINT);
+        $expandedResponse['success'] = $status == 200 || $status == 201;
+        $expandedResponse['status'] = $status;
+
+        return $expandedResponse;
     }
 
     /**
@@ -92,14 +104,24 @@ class REST implements ServiceInterface
             $path = 'athletes/' . $id;
         }
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response["body"];
+
+        return $response;
     }
 
     public function getAthleteStats($id)
     {
         $path = 'athletes/' . $id . '/stats';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteRoutes($id, $type = null, $after = null, $page = null, $per_page = null)
@@ -112,14 +134,22 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteClubs()
     {
         $path = 'athlete/clubs';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteActivities($before = null, $after = null, $page = null, $per_page = null)
@@ -132,7 +162,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteFriends($id = null, $page = null, $per_page = null)
@@ -146,7 +180,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteFollowers($id = null, $page = null, $per_page = null)
@@ -160,7 +198,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteBothFollowing($id, $page = null, $per_page = null)
@@ -171,7 +213,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteKom($id, $page = null, $per_page = null)
@@ -182,14 +228,22 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteZones()
     {
         $path = 'athlete/zones';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteStarredSegments($id = null, $page = null, $per_page = null)
@@ -204,7 +258,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function updateAthlete($city, $state, $country, $sex, $weight)
@@ -218,7 +276,11 @@ class REST implements ServiceInterface
             'weight' => $weight,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('PUT', $path, $parameters);
+        $response = $this->getResponse('PUT', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivity($id, $include_all_efforts = null)
@@ -228,7 +290,11 @@ class REST implements ServiceInterface
             'include_all_efforts' => $include_all_efforts,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityComments($id, $markdown = null, $page = null, $per_page = null)
@@ -240,7 +306,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityKudos($id, $page = null, $per_page = null)
@@ -251,7 +321,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityPhotos($id, $size = 2048, $photo_sources = 'true')
@@ -262,28 +336,44 @@ class REST implements ServiceInterface
             'photo_sources' => $photo_sources,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityZones($id)
     {
         $path = 'activities/' . $id . '/zones';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityLaps($id)
     {
         $path = 'activities/' . $id . '/laps';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityUploadStatus($id)
     {
         $path = 'uploads/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function createActivity($name, $type, $start_date_local, $elapsed_time, $description = null, $distance = null, $private = null, $trainer = null)
@@ -300,7 +390,11 @@ class REST implements ServiceInterface
             'trainer' => $trainer,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('POST', $path, $parameters);
+        $response = $this->getResponse('POST', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function uploadActivity($file, $activity_type = null, $name = null, $description = null, $private = null, $trainer = null, $commute = null, $data_type = null, $external_id = null)
@@ -319,7 +413,11 @@ class REST implements ServiceInterface
             'file_hack' => '@' . ltrim($file, '@'),
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('POST', $path, $parameters);
+        $response = $this->getResponse('POST', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function updateActivity($id, $name = null, $type = null, $private = false, $commute = false, $trainer = false, $gear_id = null, $description = null)
@@ -335,28 +433,44 @@ class REST implements ServiceInterface
             'description' => $description,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('PUT', $path, $parameters);
+        $response = $this->getResponse('PUT', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function deleteActivity($id)
     {
         $path = 'activities/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('DELETE', $path, $parameters);
+        $response = $this->getResponse('DELETE', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getGear($id)
     {
         $path = 'gear/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClub($id)
     {
         $path = 'clubs/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClubMembers($id, $page = null, $per_page = null)
@@ -367,7 +481,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClubActivities($id, $page = null, $per_page = null)
@@ -378,63 +496,99 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClubAnnouncements($id)
     {
         $path = 'clubs/' . $id . '/announcements';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClubGroupEvents($id)
     {
         $path = 'clubs/' . $id . '/group_events';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function joinClub($id)
     {
         $path = 'clubs/' . $id . '/join';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('POST', $path, $parameters);
+        $response = $this->getResponse('POST', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function leaveClub($id)
     {
         $path = 'clubs/' . $id . '/leave';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('POST', $path, $parameters);
+        $response = $this->getResponse('POST', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getRoute($id)
     {
         $path = 'routes/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getRouteAsGPX($id)
     {
         $path = 'routes/' . $id . '/export_gpx';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getRouteAsTCX($id)
     {
         $path = 'routes/' . $id . '/export_tcx';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getSegment($id)
     {
         $path = 'segments/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getSegmentLeaderboard($id, $gender = null, $age_group = null, $weight_class = null, $following = null, $club_id = null, $date_range = null, $context_entries = null, $page = null, $per_page = null)
@@ -452,7 +606,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getSegmentExplorer($bounds, $activity_type = 'riding', $min_cat = null, $max_cat = null)
@@ -465,7 +623,11 @@ class REST implements ServiceInterface
             'max_cat' => $max_cat,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getSegmentEffort($id, $athlete_id = null, $start_date_local = null, $end_date_local = null, $page = null, $per_page = null)
@@ -479,7 +641,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getStreamsActivity($id, $types, $resolution = null, $series_type = 'distance')
@@ -490,7 +656,11 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getStreamsEffort($id, $types, $resolution = null, $series_type = 'distance')
@@ -501,7 +671,11 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getStreamsSegment($id, $types, $resolution = null, $series_type = 'distance')
@@ -512,14 +686,22 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getStreamsRoute($id)
     {
         $path = 'routes/' . $id . '/streams';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
 }

--- a/tests/Strava/API/Service/RESTTest.php
+++ b/tests/Strava/API/Service/RESTTest.php
@@ -34,181 +34,316 @@ namespace Strava\API\Service {
         public function testGetAthlete()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athlete'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthlete();
+            $outputWithVerbosity = $serviceWithVerbosity->getAthlete();
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteWithId()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athletes/1234'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthlete(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getAthlete(1234);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
+
             $this->assertArrayHasKey('response', $output);
         }
 
         public function testGetStats()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athletes/1234/stats'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteStats(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteStats(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetRoutes()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athletes/1234/routes'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteRoutes(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteRoutes(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteClubs()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athlete/clubs'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteClubs();
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteClubs();
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteActivities()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athlete/activities'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteActivities();
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteActivities();
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteFriends()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athlete/friends'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteFriends();
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteFriends();
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteFriendsWithId()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athletes/1234/friends'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteFriends(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteFriends(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteFollowers()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athlete/followers'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteFollowers();
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteFollowers();
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteFollowersWithId()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athletes/1234/followers'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteFollowers(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteFollowers(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteBothFollowing()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athletes/1234/both-following'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteBothFollowing(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteBothFollowing(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteKOM()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athletes/1234/koms'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteKom(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteKom(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteZones()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athlete/zones'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteZones();
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteZones();
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteStarredSegments()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('segments/starred'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteStarredSegments();
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteStarredSegments();
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetAthleteStarredSegmentsWithId()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('athletes/1234/segments/starred'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getAthleteStarredSegments(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getAthleteStarredSegments(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testUpdateAthlete()
@@ -225,98 +360,170 @@ namespace Strava\API\Service {
             );
 
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('PUT'), $this->equalTo('athlete'), $this->equalTo($parameters))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
-            $output = $service->updateAthlete('Xyz', 'ABC', 'The Netherlands', 'M', 83.00);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
 
-            $this->assertArrayHasKey('response', $output);
+            $output = $service->updateAthlete('Xyz', 'ABC', 'The Netherlands', 'M', 83.00);
+$outputWithVerbosity = $serviceWithVerbosity->updateAthlete('Xyz', 'ABC', 'The Netherlands', 'M', 83.00);
+
+
+
+
+          $this->assertArrayHasKey('body', $outputWithVerbosity);
+          $this->assertArrayHasKey('headers', $outputWithVerbosity);
+          $this->assertArrayHasKey('status', $outputWithVerbosity);
+          $this->assertArrayHasKey('success', $outputWithVerbosity);$this->assertArrayHasKey('response', $output);
         }
 
         public function testGetActivity()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('activities/1234'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getActivity(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getActivity(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetActivityComments()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('activities/1234/comments'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getActivityComments(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getActivityComments(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetActivityKudos()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('activities/1234/kudos'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getActivityKudos(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getActivityKudos(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetActivityPhotos()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('activities/1234/photos'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getActivityPhotos(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getActivityPhotos(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetActivityZones()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('activities/1234/zones'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getActivityZones(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getActivityZones(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetActivityLaps()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('activities/1234/laps'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getActivityLaps(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getActivityLaps(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetActivityUploadStatus()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('uploads/1234'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getActivityUploadStatus(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getActivityUploadStatus(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testCreateActivity()
@@ -333,13 +540,22 @@ namespace Strava\API\Service {
                 'access_token' => static::TOKEN,
             ];
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('POST'), $this->equalTo('activities'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->createActivity('test', 'test', '20130101', 100);
+            $outputWithVerbosity = $serviceWithVerbosity->createActivity('test', 'test', '20130101', 100);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testUploadActivity()
@@ -357,146 +573,255 @@ namespace Strava\API\Service {
                 'file_hack' => '@' . ltrim('file', '@'),
                 'access_token' => static::TOKEN,
             ];
+
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('POST'), $this->equalTo('uploads'), $parameters)
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->uploadActivity('file');
+            $outputWithVerbosity = $serviceWithVerbosity->uploadActivity('file');
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testUpdateActivity()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('PUT'), $this->equalTo('activities/1234'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->updateActivity(1234, 'test');
+            $outputWithVerbosity = $serviceWithVerbosity->updateActivity(1234, 'test');
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testDeleteActivity()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('DELETE'), $this->equalTo('activities/1234'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->deleteActivity(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->deleteActivity(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetGear()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('gear/1234'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getGear(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getGear(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetClub()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('clubs/1234'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getClub(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getClub(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetClubMembers()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('clubs/1234/members'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getClubMembers(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getClubMembers(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetClubActivities()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('clubs/1234/activities'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getClubActivities(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getClubActivities(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetClubAnnouncements()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('clubs/1234/announcements'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getClubAnnouncements(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getClubAnnouncements(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetClubGroupEvents()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('clubs/1234/group_events'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getClubGroupEvents(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getClubGroupEvents(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testJoinClub()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('POST'), $this->equalTo('clubs/1234/join'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->joinClub(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->joinClub(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testLeaveClub()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('POST'), $this->equalTo('clubs/1234/leave'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->leaveClub(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->leaveClub(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetRoute()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('routes/1234'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getRoute(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getRoute(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetRouteAsGPX()
@@ -526,97 +851,169 @@ namespace Strava\API\Service {
         public function testGetSegment()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('segments/1234'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getSegment(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getSegment(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetSegmentLeaderboard()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('segments/1234/leaderboard'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getSegmentLeaderboard(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getSegmentLeaderboard(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetSegmentExplorer()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('segments/explore'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getSegmentExplorer('37.821362,-122.505373,37.842038,-122.465977');
+            $outputWithVerbosity = $serviceWithVerbosity->getSegmentExplorer('37.821362,-122.505373,37.842038,-122.465977');
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetSegmentEffort()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('segments/1234/all_efforts'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getSegmentEffort(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getSegmentEffort(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetStreamsActivity()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('activities/1234/streams/latlng'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getStreamsActivity(1234, 'latlng');
+            $outputWithVerbosity = $serviceWithVerbosity->getStreamsActivity(1234, 'latlng');
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetStreamsEffort()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('segment_efforts/1234/streams/latlng'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getStreamsEffort(1234, 'latlng');
+            $outputWithVerbosity = $serviceWithVerbosity->getStreamsEffort(1234, 'latlng');
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetStreamsSegment()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('segments/1234/streams/latlng'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getStreamsSegment(1234, 'latlng');
+            $outputWithVerbosity = $serviceWithVerbosity->getStreamsSegment(1234, 'latlng');
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
 
         public function testGetStreamsRoute()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('request')
+            $restMock->expects($this->exactly(2))->method('request')
                 ->with($this->equalTo('GET'), $this->equalTo('routes/1234/streams'))
                 ->will($this->returnValue(new \GuzzleHttp\Psr7\Response(200, [], '{"response": 1}')));
 
             $service = new \Strava\API\Service\REST(static::TOKEN, $restMock);
+            $serviceWithVerbosity = new \Strava\API\Service\REST(static::TOKEN, $restMock, 1);
+
             $output = $service->getStreamsRoute(1234);
+            $outputWithVerbosity = $serviceWithVerbosity->getStreamsRoute(1234);
+
             $this->assertArrayHasKey('response', $output);
+
+            $this->assertArrayHasKey('body', $outputWithVerbosity);
+            $this->assertArrayHasKey('headers', $outputWithVerbosity);
+            $this->assertArrayHasKey('status', $outputWithVerbosity);
+            $this->assertArrayHasKey('success', $outputWithVerbosity);
         }
     }
 }


### PR DESCRIPTION
Allow users of Strava API to access the headers, and status code in their application if desires, addressing requirements in https://github.com/basvandorst/StravaPHP/issues/49.

This is a non-breaking change as the response verbosity defaults to 0, i.e. the current implementation.
The response verbosity can be changed by specifying a non-zero value in the REST constructor.