### PR TITLE
Fix getRouteAs endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - 7.1
+  - 7.3
 install:
   - composer --no-interaction install
 script: phpunit --configuration phpunit.xml --coverage-clover=coverage.clover

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -64,6 +64,11 @@ class REST implements ServiceInterface
      */
     protected function getResult($response)
     {
+        // Workaround for export methods getRouteAsGPX, getRouteAsTCX:
+        if (is_string($response)) {
+            return $response;
+        }
+
         $status = $response->getStatusCode();
 
         $expandedResponse = [];
@@ -565,8 +570,6 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
         return $response;
     }
 
@@ -576,8 +579,6 @@ class REST implements ServiceInterface
         $parameters['query'] = ['access_token' => $this->getToken()];
         $response = $this->getResponse('GET', $path, $parameters);
 
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
         return $response;
     }
 

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -34,11 +34,12 @@ class REST implements ServiceInterface
     protected $responseVerbosity;
 
     /**
-     * Initiate this REST service with the application token and a instance
-     * of the REST adapter (Guzzle).
+     * Initiate this REST service with the application token, a instance
+     * of the REST adapter (Guzzle) and a level of verbosity for the response.
      *
      * @param string $token
      * @param Client $adapter
+     * @param integer $responseVerbosity
      */
     public function __construct($token, Client $adapter, $responseVerbosity = 0)
     {

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -29,7 +29,7 @@ class REST implements ServiceInterface
      * Specifies the verbosity of the HTTP response
      * 0 = basic, just body
      * 1 = enhanced, [body, headers, status]
-     * @var int|mixed
+     * @var int
      */
     protected $responseVerbosity;
 
@@ -39,7 +39,7 @@ class REST implements ServiceInterface
      *
      * @param string $token
      * @param Client $adapter
-     * @param integer $responseVerbosity
+     * @param int $responseVerbosity
      */
     public function __construct($token, Client $adapter, $responseVerbosity = 0)
     {

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -26,19 +26,28 @@ class REST implements ServiceInterface
     protected $token;
 
     /**
+     * Specifies the verbosity of the HTTP response
+     * 0 = basic, just body
+     * 1 = enhanced, [body, headers, status]
+     * @var int|mixed
+     */
+    protected $responseVerbosity;
+
+    /**
      * Initiate this REST service with the application token and a instance
      * of the REST adapter (Guzzle).
      *
      * @param string $token
      * @param Client $adapter
      */
-    public function __construct($token, Client $adapter)
+    public function __construct($token, Client $adapter, $responseVerbosity = 0)
     {
         if (is_object($token) && method_exists($token, 'getToken')) {
             $token = $token->getToken();
         }
         $this->token = $token;
         $this->adapter = $adapter;
+        $this->responseVerbosity = $responseVerbosity;
     }
 
     protected function getToken()
@@ -56,11 +65,14 @@ class REST implements ServiceInterface
     {
         $status = $response->getStatusCode();
 
-        if ($status == 200 || $status == 201) {
-            return json_decode($response->getBody(), JSON_PRETTY_PRINT);
-        } else {
-            return [$status => $response->getReasonPhrase()];
-        }
+        $expandedResponse = [];
+
+        $expandedResponse['headers'] = $response->getHeaders();
+        $expandedResponse['body'] = json_decode($response->getBody(), JSON_PRETTY_PRINT);
+        $expandedResponse['success'] = $status == 200 || $status == 201;
+        $expandedResponse['status'] = $status;
+
+        return $expandedResponse;
     }
 
     /**
@@ -92,14 +104,24 @@ class REST implements ServiceInterface
             $path = 'athletes/' . $id;
         }
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response["body"];
+
+        return $response;
     }
 
     public function getAthleteStats($id)
     {
         $path = 'athletes/' . $id . '/stats';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteRoutes($id, $type = null, $after = null, $page = null, $per_page = null)
@@ -112,14 +134,22 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteClubs()
     {
         $path = 'athlete/clubs';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteActivities($before = null, $after = null, $page = null, $per_page = null)
@@ -132,7 +162,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteFriends($id = null, $page = null, $per_page = null)
@@ -146,7 +180,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteFollowers($id = null, $page = null, $per_page = null)
@@ -160,7 +198,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteBothFollowing($id, $page = null, $per_page = null)
@@ -171,7 +213,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteKom($id, $page = null, $per_page = null)
@@ -182,14 +228,22 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteZones()
     {
         $path = 'athlete/zones';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getAthleteStarredSegments($id = null, $page = null, $per_page = null)
@@ -204,7 +258,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function updateAthlete($city, $state, $country, $sex, $weight)
@@ -218,7 +276,11 @@ class REST implements ServiceInterface
             'weight' => $weight,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('PUT', $path, $parameters);
+        $response = $this->getResponse('PUT', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivity($id, $include_all_efforts = null)
@@ -228,7 +290,11 @@ class REST implements ServiceInterface
             'include_all_efforts' => $include_all_efforts,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityComments($id, $markdown = null, $page = null, $per_page = null)
@@ -240,7 +306,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityKudos($id, $page = null, $per_page = null)
@@ -251,7 +321,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityPhotos($id, $size = 2048, $photo_sources = 'true')
@@ -262,28 +336,44 @@ class REST implements ServiceInterface
             'photo_sources' => $photo_sources,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityZones($id)
     {
         $path = 'activities/' . $id . '/zones';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityLaps($id)
     {
         $path = 'activities/' . $id . '/laps';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getActivityUploadStatus($id)
     {
         $path = 'uploads/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function createActivity($name, $type, $start_date_local, $elapsed_time, $description = null, $distance = null, $private = null, $trainer = null)
@@ -300,7 +390,11 @@ class REST implements ServiceInterface
             'trainer' => $trainer,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('POST', $path, $parameters);
+        $response = $this->getResponse('POST', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function uploadActivity($file, $activity_type = null, $name = null, $description = null, $private = null, $trainer = null, $commute = null, $data_type = null, $external_id = null)
@@ -319,7 +413,11 @@ class REST implements ServiceInterface
             'file_hack' => '@' . ltrim($file, '@'),
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('POST', $path, $parameters);
+        $response = $this->getResponse('POST', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function updateActivity($id, $name = null, $type = null, $private = false, $commute = false, $trainer = false, $gear_id = null, $description = null)
@@ -335,28 +433,44 @@ class REST implements ServiceInterface
             'description' => $description,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('PUT', $path, $parameters);
+        $response = $this->getResponse('PUT', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function deleteActivity($id)
     {
         $path = 'activities/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('DELETE', $path, $parameters);
+        $response = $this->getResponse('DELETE', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getGear($id)
     {
         $path = 'gear/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClub($id)
     {
         $path = 'clubs/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClubMembers($id, $page = null, $per_page = null)
@@ -367,7 +481,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClubActivities($id, $page = null, $per_page = null)
@@ -378,63 +496,99 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClubAnnouncements($id)
     {
         $path = 'clubs/' . $id . '/announcements';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getClubGroupEvents($id)
     {
         $path = 'clubs/' . $id . '/group_events';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function joinClub($id)
     {
         $path = 'clubs/' . $id . '/join';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('POST', $path, $parameters);
+        $response = $this->getResponse('POST', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function leaveClub($id)
     {
         $path = 'clubs/' . $id . '/leave';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('POST', $path, $parameters);
+        $response = $this->getResponse('POST', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getRoute($id)
     {
         $path = 'routes/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getRouteAsGPX($id)
     {
         $path = 'routes/' . $id . '/export_gpx';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getRouteAsTCX($id)
     {
         $path = 'routes/' . $id . '/export_tcx';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getSegment($id)
     {
         $path = 'segments/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getSegmentLeaderboard($id, $gender = null, $age_group = null, $weight_class = null, $following = null, $club_id = null, $date_range = null, $context_entries = null, $page = null, $per_page = null)
@@ -452,7 +606,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getSegmentExplorer($bounds, $activity_type = 'riding', $min_cat = null, $max_cat = null)
@@ -465,7 +623,11 @@ class REST implements ServiceInterface
             'max_cat' => $max_cat,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getSegmentEffort($id, $athlete_id = null, $start_date_local = null, $end_date_local = null, $page = null, $per_page = null)
@@ -479,7 +641,11 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getStreamsActivity($id, $types, $resolution = null, $series_type = 'distance')
@@ -490,7 +656,11 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getStreamsEffort($id, $types, $resolution = null, $series_type = 'distance')
@@ -501,7 +671,11 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getStreamsSegment($id, $types, $resolution = null, $series_type = 'distance')
@@ -512,14 +686,22 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
     public function getStreamsRoute($id)
     {
         $path = 'routes/' . $id . '/streams';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        return $this->getResponse('GET', $path, $parameters);
+        $response = $this->getResponse('GET', $path, $parameters);
+
+        if ($this->responseVerbosity == 0)
+            return $response['body'];
+        return $response;
     }
 
 }

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -26,29 +26,19 @@ class REST implements ServiceInterface
     protected $token;
 
     /**
-     * Specifies the verbosity of the HTTP response
-     * 0 = basic, just body
-     * 1 = enhanced, [body, headers, status]
-     * @var int
-     */
-    protected $responseVerbosity;
-
-    /**
-     * Initiate this REST service with the application token, a instance
-     * of the REST adapter (Guzzle) and a level of verbosity for the response.
+     * Initiate this REST service with the application token and a instance
+     * of the REST adapter (Guzzle).
      *
      * @param string $token
      * @param Client $adapter
-     * @param int $responseVerbosity
      */
-    public function __construct($token, Client $adapter, $responseVerbosity = 0)
+    public function __construct($token, Client $adapter)
     {
         if (is_object($token) && method_exists($token, 'getToken')) {
             $token = $token->getToken();
         }
         $this->token = $token;
         $this->adapter = $adapter;
-        $this->responseVerbosity = $responseVerbosity;
     }
 
     protected function getToken()
@@ -71,14 +61,11 @@ class REST implements ServiceInterface
 
         $status = $response->getStatusCode();
 
-        $expandedResponse = [];
-
-        $expandedResponse['headers'] = $response->getHeaders();
-        $expandedResponse['body'] = json_decode($response->getBody(), JSON_PRETTY_PRINT);
-        $expandedResponse['success'] = $status == 200 || $status == 201;
-        $expandedResponse['status'] = $status;
-
-        return $expandedResponse;
+        if ($status == 200 || $status == 201) {
+            return json_decode($response->getBody(), JSON_PRETTY_PRINT);
+        } else {
+            return [$status => $response->getReasonPhrase()];
+        }
     }
 
     /**
@@ -110,24 +97,14 @@ class REST implements ServiceInterface
             $path = 'athletes/' . $id;
         }
         $parameters['query'] = ['access_token' => $this->getToken()];
-
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response["body"];
-
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteStats($id)
     {
         $path = 'athletes/' . $id . '/stats';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteRoutes($id, $type = null, $after = null, $page = null, $per_page = null)
@@ -140,22 +117,14 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteClubs()
     {
         $path = 'athlete/clubs';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteActivities($before = null, $after = null, $page = null, $per_page = null)
@@ -168,11 +137,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteFriends($id = null, $page = null, $per_page = null)
@@ -186,11 +151,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteFollowers($id = null, $page = null, $per_page = null)
@@ -204,11 +165,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteBothFollowing($id, $page = null, $per_page = null)
@@ -219,11 +176,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteKom($id, $page = null, $per_page = null)
@@ -234,22 +187,14 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteZones()
     {
         $path = 'athlete/zones';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getAthleteStarredSegments($id = null, $page = null, $per_page = null)
@@ -264,11 +209,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function updateAthlete($city, $state, $country, $sex, $weight)
@@ -282,11 +223,7 @@ class REST implements ServiceInterface
             'weight' => $weight,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('PUT', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('PUT', $path, $parameters);
     }
 
     public function getActivity($id, $include_all_efforts = null)
@@ -296,11 +233,7 @@ class REST implements ServiceInterface
             'include_all_efforts' => $include_all_efforts,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityComments($id, $markdown = null, $page = null, $per_page = null)
@@ -312,11 +245,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityKudos($id, $page = null, $per_page = null)
@@ -327,11 +256,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityPhotos($id, $size = 2048, $photo_sources = 'true')
@@ -342,44 +267,28 @@ class REST implements ServiceInterface
             'photo_sources' => $photo_sources,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityZones($id)
     {
         $path = 'activities/' . $id . '/zones';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityLaps($id)
     {
         $path = 'activities/' . $id . '/laps';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getActivityUploadStatus($id)
     {
         $path = 'uploads/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function createActivity($name, $type, $start_date_local, $elapsed_time, $description = null, $distance = null, $private = null, $trainer = null)
@@ -396,11 +305,7 @@ class REST implements ServiceInterface
             'trainer' => $trainer,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('POST', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('POST', $path, $parameters);
     }
 
     public function uploadActivity($file, $activity_type = null, $name = null, $description = null, $private = null, $trainer = null, $commute = null, $data_type = null, $external_id = null)
@@ -419,11 +324,7 @@ class REST implements ServiceInterface
             'file_hack' => '@' . ltrim($file, '@'),
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('POST', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('POST', $path, $parameters);
     }
 
     public function updateActivity($id, $name = null, $type = null, $private = false, $commute = false, $trainer = false, $gear_id = null, $description = null)
@@ -439,44 +340,28 @@ class REST implements ServiceInterface
             'description' => $description,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('PUT', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('PUT', $path, $parameters);
     }
 
     public function deleteActivity($id)
     {
         $path = 'activities/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('DELETE', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('DELETE', $path, $parameters);
     }
 
     public function getGear($id)
     {
         $path = 'gear/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClub($id)
     {
         $path = 'clubs/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClubMembers($id, $page = null, $per_page = null)
@@ -487,11 +372,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClubActivities($id, $page = null, $per_page = null)
@@ -502,95 +383,63 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClubAnnouncements($id)
     {
         $path = 'clubs/' . $id . '/announcements';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getClubGroupEvents($id)
     {
         $path = 'clubs/' . $id . '/group_events';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function joinClub($id)
     {
         $path = 'clubs/' . $id . '/join';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('POST', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('POST', $path, $parameters);
     }
 
     public function leaveClub($id)
     {
         $path = 'clubs/' . $id . '/leave';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('POST', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('POST', $path, $parameters);
     }
 
     public function getRoute($id)
     {
         $path = 'routes/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getRouteAsGPX($id)
     {
         $path = 'routes/' . $id . '/export_gpx';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getRouteAsTCX($id)
     {
         $path = 'routes/' . $id . '/export_tcx';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getSegment($id)
     {
         $path = 'segments/' . $id;
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getSegmentLeaderboard($id, $gender = null, $age_group = null, $weight_class = null, $following = null, $club_id = null, $date_range = null, $context_entries = null, $page = null, $per_page = null)
@@ -608,11 +457,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getSegmentExplorer($bounds, $activity_type = 'riding', $min_cat = null, $max_cat = null)
@@ -625,11 +470,7 @@ class REST implements ServiceInterface
             'max_cat' => $max_cat,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getSegmentEffort($id, $athlete_id = null, $start_date_local = null, $end_date_local = null, $page = null, $per_page = null)
@@ -643,11 +484,7 @@ class REST implements ServiceInterface
             'per_page' => $per_page,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getStreamsActivity($id, $types, $resolution = null, $series_type = 'distance')
@@ -658,11 +495,7 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getStreamsEffort($id, $types, $resolution = null, $series_type = 'distance')
@@ -673,11 +506,7 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getStreamsSegment($id, $types, $resolution = null, $series_type = 'distance')
@@ -688,22 +517,14 @@ class REST implements ServiceInterface
             'series_type' => $series_type,
             'access_token' => $this->getToken(),
         ];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
     public function getStreamsRoute($id)
     {
         $path = 'routes/' . $id . '/streams';
         $parameters['query'] = ['access_token' => $this->getToken()];
-        $response = $this->getResponse('GET', $path, $parameters);
-
-        if ($this->responseVerbosity == 0)
-            return $response['body'];
-        return $response;
+        return $this->getResponse('GET', $path, $parameters);
     }
 
 }

--- a/tests/Strava/API/Service/RESTTest.php
+++ b/tests/Strava/API/Service/RESTTest.php
@@ -502,8 +502,8 @@ namespace Strava\API\Service {
         public function testGetRouteAsGPX()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('get')
-                ->with($this->equalTo('routes/1234/export_gpx'))
+            $restMock->expects($this->once())->method('request')
+                ->with($this->equalTo('GET'), $this->equalTo('routes/1234/export_gpx'))
                 ->will($this->returnValue('<?xml version="1.0" encoding="UTF-8"?><gpx creator="StravaGPX"/>'));
 
             $service = new \Strava\API\Service\REST('TOKEN', $restMock);
@@ -514,8 +514,8 @@ namespace Strava\API\Service {
         public function testGetRouteAsTCX()
         {
             $restMock = $this->getRestMock();
-            $restMock->expects($this->once())->method('get')
-                ->with($this->equalTo('routes/1234/export_tcx'))
+            $restMock->expects($this->once())->method('request')
+                ->with($this->equalTo('GET'), $this->equalTo('routes/1234/export_tcx'))
                 ->will($this->returnValue('<?xml version="1.0" encoding="UTF-8"?><TrainingCenterDatabase/>'));
 
             $service = new \Strava\API\Service\REST('TOKEN', $restMock);


### PR DESCRIPTION
Flakey tests appear to show the `getRouteAs[...]` endpoints as working, however they were not.

This bugfix corrects the tests and then the implementation for the `getRouteAsGPX` and `getRouteAsTCX` functions.