### PR TITLE
Fix failing unit tests for GPX and TCX exports

### DIFF
--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -97,7 +97,7 @@ class REST implements ServiceInterface
             $response = $this->adapter->request($method, $path, $parameters);
             $result = $this->getResult($response);
 
-            if ($this->responseVerbosity === 0)
+            if ($this->responseVerbosity === 0 && !is_string($result))
                 return $result["body"];
 
             return $result;


### PR DESCRIPTION
@vredeling during the refactor of https://github.com/basvandorst/StravaPHP/pull/67, the `getRouteAsGPX` and `getRouteAsTCX` functions were broken.

Small PR to add a `is_string()` check to prevent errors.