### PR TITLE
Property Types

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1']
 
     steps:
       - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": "^7.4 || ^8.0",
     "ext-curl": "*",
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3 || ^7.0.1",

--- a/src/Strava/API/Client.php
+++ b/src/Strava/API/Client.php
@@ -15,9 +15,8 @@ use Strava\API\Service\Exception as ServiceException;
 class Client
 {
     /**
-     * @var ServiceInterface
      */
-    protected $service;
+    protected ServiceInterface $service;
 
     /**
      * Initiate this class with a subclass of ServiceInterface. There are two
@@ -25,7 +24,6 @@ class Client
      * - Service\REST: Service which makes calls to the live Strava API
      * - Service\Stub: Service stub for test purposes (unit tests)
      *
-     * @param ServiceInterface $service
      */
     public function __construct(ServiceInterface $service)
     {
@@ -411,7 +409,6 @@ class Client
      * Upload an activity
      *
      * @link    https://strava.github.io/api/v3/uploads/#post-file
-     * @param mixed $file
      * @param string $activity_type
      * @param string $name
      * @param string $description

--- a/src/Strava/API/Factory.php
+++ b/src/Strava/API/Factory.php
@@ -12,9 +12,8 @@ class Factory
 {
     /**
      * Strava V3 endpoint
-     * @var string
      */
-    private static $endpoint = 'https://www.strava.com/api/v3/';
+    private static string $endpoint = 'https://www.strava.com/api/v3/';
 
     /**
      * Return a new instance of the OAuth Client

--- a/src/Strava/API/Service/REST.php
+++ b/src/Strava/API/Service/REST.php
@@ -16,30 +16,26 @@ class REST implements ServiceInterface
 {
     /**
      * REST adapter
-     * @var Client
      */
-    protected $adapter;
+    protected Client $adapter;
 
     /**
      * Application token
-     * @var string
      */
-    protected $token;
+    protected string $token;
 
     /**
      * Specifies the verbosity of the HTTP response.
      * 0 = basic, just body
      * 1 = enhanced, [body, headers, status]
-     * @var int
      */
-    protected $responseVerbosity;
+    protected int $responseVerbosity;
 
     /**
      * Initiate this REST service with the application token, a instance
      * of the REST adapter (Guzzle) and a level of verbosity for the response.
      *
      * @param string|AccessTokenInterface $token
-     * @param Client $adapter
      * @param int $responseVerbosity
      */
     public function __construct($token, Client $adapter, $responseVerbosity = 0)

--- a/src/Strava/API/Service/Stub.php
+++ b/src/Strava/API/Service/Stub.php
@@ -270,7 +270,6 @@ class Stub implements ServiceInterface
 
     /**
      * @param string $result
-     * @return mixed
      */
     private function format($result)
     {


### PR DESCRIPTION
This is the first potential breaking change. Ups the PHP requirement to 7.4 and applies property types (where possible).

Not sure what the plans for updates are, but it might be good to start a new branch `v2` or `php74` or something to put all breaking changes toward until the roadmap is clear.