### PR TITLE
Possible fix for invalid authorization code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "basvandorst/stravaphp",
+  "name": "absoftware/basvandorst-strava-php",
   "description": "Strava V3 API PHP client with OAuth authentication",
   "keywords": [
     "Strava",

--- a/src/Strava/API/OAuth.php
+++ b/src/Strava/API/OAuth.php
@@ -35,7 +35,7 @@ class OAuth extends AbstractProvider
      */
     public function urlAccessToken(): string
     {
-        return 'https://www.strava.com/oauth/token';
+        return 'https://www.strava.com/api/v3/oauth/token';
     }
 
     /**
@@ -102,7 +102,7 @@ class OAuth extends AbstractProvider
      */
     public function getBaseAccessTokenUrl(array $params): string
     {
-        return 'https://www.strava.com/oauth/token';
+        return 'https://www.strava.com/api/v3/oauth/token';
     }
 
     /**

--- a/tests/Strava/API/OAuthTest.php
+++ b/tests/Strava/API/OAuthTest.php
@@ -91,6 +91,6 @@ final class OAuthTest extends TestCase
     {
         $result = $this->oauth->getBaseAccessTokenUrl(array());
 
-        $this->assertSame('https://www.strava.com/oauth/token', $result);
+        $this->assertSame('https://www.strava.com/api/v3/oauth/token', $result);
     }
 }


### PR DESCRIPTION
Possible fix for issues:

- https://github.com/basvandorst/StravaPHP/issues/94
- https://github.com/basvandorst/StravaPHP/issues/96

I sent the ticket to developers@strava.com and it returned me automatic reply that I can check docs just in case once again. I found there:

<img width="1690" alt="Screenshot 2025-03-28 at 19 16 37" src="https://github.com/user-attachments/assets/74f93429-f41d-4ce0-8948-55f255e24ee8" />

When I test authorization for:

- https://www.strava.com/oauth/token - I get invalid token once a 6-10 tries
- https://www.strava.com/api/v3/oauth/token - I get only valid tokens (30-40 manual tests)

So it is still not a proof, but I see the difference.